### PR TITLE
Updating the imports to the new plugin structure

### DIFF
--- a/xmipp3/__init__.py
+++ b/xmipp3/__init__.py
@@ -1,8 +1,10 @@
 # **************************************************************************
 # *
 # * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# *              David Maluenda Niubo (dmaluenda@cnb.csic.es) [2]
 # *
 # * [1] SciLifeLab, Stockholm University
+# * [2] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -26,7 +28,7 @@
 
 import pyworkflow.em
 import pyworkflow.utils as pwutils
-from .constants import XMIPP_HOME
+from xmipp3.constants import XMIPP_HOME
 from base import *
 
 _logo = "xmipp_logo.png"

--- a/xmipp3/base.py
+++ b/xmipp3/base.py
@@ -30,7 +30,7 @@ import os
 import sys
 import platform
 from collections import OrderedDict
-from .constants import *
+from xmipp3.constants import *
 
 import xmipp
 import pyworkflow.dataset as ds

--- a/xmipp3/convert/dataimport.py
+++ b/xmipp3/convert/dataimport.py
@@ -31,7 +31,7 @@ from pyworkflow.utils.path import findRootFrom, copyTree, createLink, replaceExt
 from pyworkflow.em.data import Micrograph
 import pyworkflow.em.metadata as md
 
-from .convert import *
+from xmipp3.convert import *
 
 
 

--- a/xmipp3/protocols/__init__.py
+++ b/xmipp3/protocols/__init__.py
@@ -1,8 +1,10 @@
 # **************************************************************************
 # *
 # * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# *              David Maluenda Niubo (dmaluenda@cnb.csic.es) [2]
 # *
 # * [1] SciLifeLab, Stockholm University
+# * [2] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -31,83 +33,83 @@
 
 #FIXME: Uncomment protocols and fix the import issues
 
-# from nma import *
-# from pdb import *
-#from protocol_preprocess import *
+from nma import *
+from pdb import *
+from xmipp3.protocols.protocol_preprocess import *
 
 
 #ROB no file protocol_3dbionotes in devel
-#from protocol_3dbionotes import XmippProt3DBionotes
+#from xmipp3.protocols.protocol_3dbionotes import XmippProt3DBionotes
 
-# from protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
-# from protocol_align_volume import XmippProtAlignVolume, XmippProtAlignVolumeForWeb
-# from protocol_preprocess.protocol_add_noise import (
-#     XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles)
-# from protocol_apply_alignment import XmippProtApplyAlignment
-# from protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
-# from protocol_break_symmetry import XmippProtAngBreakSymmetry
-# from protocol_cl2d_align import XmippProtCL2DAlign
-# from protocol_cl2d import XmippProtCL2D
-# from protocol_cltomo import XmippProtCLTomo
-# #AJ
-# from protocol_classification_gpuCorr import XmippProtGpuCrrCL2D
-# from protocol_classification_gpuCorr_semi import XmippProtStrGpuCrrSimple
-# from protocol_classification_gpuCorr_full import XmippProtStrGpuCrrCL2D
-# #END
-# # from protocol_ctf_defocus_group import XmippProtCTFDefocusGroup
-# from protocol_compare_reprojections import XmippProtCompareReprojections
-# from protocol_compare_angles import XmippProtCompareAngles
-# from protocol_create_gallery import XmippProtCreateGallery
-# from protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
-# from protocol_ctf_micrographs import XmippProtCTFMicrographs
-# from protocol_ctf_correct_wiener2d import XmippProtCTFCorrectWiener2D
-# from protocol_consensus_classes3D import XmippProtConsensusClasses3D
-# from protocol_subtract_projection import XmippProtSubtractProjection
-# from protocol_denoise_particles import XmippProtDenoiseParticles
-# from protocol_eliminate_empty_particles import XmippProtEliminateEmptyParticles
-# from protocol_extract_particles import XmippProtExtractParticles
-# from protocol_extract_particles_movies import XmippProtExtractMovieParticles
-# from protocol_extract_particles_pairs import XmippProtExtractParticlesPairs
-# from protocol_extract_unit_cell import XmippProtExtractUnit
-# from protocol_helical_parameters import XmippProtHelicalParameters
-# from protocol_kerdensom import XmippProtKerdensom
-# from protocol_ml2d import XmippProtML2D
-# from protocol_movie_gain import XmippProtMovieGain
-# from protocol_mltomo import XmippProtMLTomo
-# from protocol_movie_average import XmippProtMovieAverage
-# from protocol_movie_correlation import XmippProtMovieCorr
-# from protocol_movie_opticalflow import XmippProtOFAlignment, ProtMovieAlignment
-# from protocol_movie_max_shift import XmippProtMovieMaxShift
-# from protocol_multiple_fscs import XmippProtMultipleFSCs
-# from protocol_multireference_alignability import XmippProtMultiRefAlignability
-# from protocol_normalize_strain import XmippProtNormalizeStrain
-# from protocol_particle_pick_automatic import XmippParticlePickingAutomatic
-# from protocol_particle_pick_consensus import XmippProtConsensusPicking
-# from protocol_particle_pick import XmippProtParticlePicking
-# from protocol_particle_pick_pairs import XmippProtParticlePickingPairs
-# from protocol_preprocess_micrographs import XmippProtPreprocessMicrographs
-# from protocol_projmatch import XmippProtProjMatch, XmippProjMatchViewer
-# from protocol_random_conical_tilt import XmippProtRCT
-# from protocol_ransac import XmippProtRansac
-# from protocol_reconstruct_fourier import XmippProtReconstructFourier
-# from protocol_reconstruct_highres import XmippProtReconstructHighRes
-# from protocol_reconstruct_significant import XmippProtReconstructSignificant
-# from protocol_reconstruct_swarm import XmippProtReconstructSwarm
-# from protocol_resolution3d import XmippProtResolution3D
-# from protocol_resolution_monogenic_signal import XmippProtMonoRes
-# from protocol_rotational_spectra import XmippProtRotSpectra
-# from protocol_rotational_symmetry import XmippProtRotationalSymmetry
-# from protocol_screen_particles import XmippProtScreenParticles
-# from protocol_solid_angles import XmippProtSolidAngles
-# from protocol_split_volume import XmippProtSplitvolume
-# from protocol_trigger_data import XmippProtTriggerData
-# from protocol_validate_nontilt import XmippProtValidateNonTilt
-# from protocol_validate_overfitting import XmippProtValidateOverfitting
-# # from protocol_validate_tilt import XmippProtValidateTilt
-# from protocol_volume_strain import XmippProtVolumeStrain
-# from protocol_volume_homogenizer import XmippProtVolumeHomogenizer
-# from protocol_write_testC import XmippProtWriteTestC
-# from protocol_write_testP import XmippProtWriteTestP
-# from protocol_ctf_selection import XmippProtCTFSelection
-# #AJ
-# from protocol_realignment_classes import XmippProtReAlignClasses
+from xmipp3.protocols.protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
+from xmipp3.protocols.protocol_align_volume import XmippProtAlignVolume, XmippProtAlignVolumeForWeb
+from xmipp3.protocols.protocol_preprocess.protocol_add_noise import (
+    XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles)
+from xmipp3.protocols.protocol_apply_alignment import XmippProtApplyAlignment
+from xmipp3.protocols.protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
+from xmipp3.protocols.protocol_break_symmetry import XmippProtAngBreakSymmetry
+from xmipp3.protocols.protocol_cl2d_align import XmippProtCL2DAlign
+from xmipp3.protocols.protocol_cl2d import XmippProtCL2D
+from xmipp3.protocols.protocol_cltomo import XmippProtCLTomo
+#AJ
+from xmipp3.protocols.protocol_classification_gpuCorr import XmippProtGpuCrrCL2D
+from xmipp3.protocols.protocol_classification_gpuCorr_semi import XmippProtStrGpuCrrSimple
+from xmipp3.protocols.protocol_classification_gpuCorr_full import XmippProtStrGpuCrrCL2D
+#END
+# from xmipp3.protocols.protocol_ctf_defocus_group import XmippProtCTFDefocusGroup
+from xmipp3.protocols.protocol_compare_reprojections import XmippProtCompareReprojections
+from xmipp3.protocols.protocol_compare_angles import XmippProtCompareAngles
+from xmipp3.protocols.protocol_create_gallery import XmippProtCreateGallery
+from xmipp3.protocols.protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
+from xmipp3.protocols.protocol_ctf_micrographs import XmippProtCTFMicrographs
+from xmipp3.protocols.protocol_ctf_correct_wiener2d import XmippProtCTFCorrectWiener2D
+from xmipp3.protocols.protocol_consensus_classes3D import XmippProtConsensusClasses3D
+from xmipp3.protocols.protocol_subtract_projection import XmippProtSubtractProjection
+from xmipp3.protocols.protocol_denoise_particles import XmippProtDenoiseParticles
+from xmipp3.protocols.protocol_eliminate_empty_particles import XmippProtEliminateEmptyParticles
+from xmipp3.protocols.protocol_extract_particles import XmippProtExtractParticles
+from xmipp3.protocols.protocol_extract_particles_movies import XmippProtExtractMovieParticles
+from xmipp3.protocols.protocol_extract_particles_pairs import XmippProtExtractParticlesPairs
+from xmipp3.protocols.protocol_extract_unit_cell import XmippProtExtractUnit
+from xmipp3.protocols.protocol_helical_parameters import XmippProtHelicalParameters
+from xmipp3.protocols.protocol_kerdensom import XmippProtKerdensom
+from xmipp3.protocols.protocol_ml2d import XmippProtML2D
+from xmipp3.protocols.protocol_movie_gain import XmippProtMovieGain
+from xmipp3.protocols.protocol_mltomo import XmippProtMLTomo
+from xmipp3.protocols.protocol_movie_average import XmippProtMovieAverage
+from xmipp3.protocols.protocol_movie_correlation import XmippProtMovieCorr
+from xmipp3.protocols.protocol_movie_opticalflow import XmippProtOFAlignment, ProtMovieAlignment
+from xmipp3.protocols.protocol_movie_max_shift import XmippProtMovieMaxShift
+from xmipp3.protocols.protocol_multiple_fscs import XmippProtMultipleFSCs
+from xmipp3.protocols.protocol_multireference_alignability import XmippProtMultiRefAlignability
+from xmipp3.protocols.protocol_normalize_strain import XmippProtNormalizeStrain
+from xmipp3.protocols.protocol_particle_pick_automatic import XmippParticlePickingAutomatic
+from xmipp3.protocols.protocol_particle_pick_consensus import XmippProtConsensusPicking
+from xmipp3.protocols.protocol_particle_pick import XmippProtParticlePicking
+from xmipp3.protocols.protocol_particle_pick_pairs import XmippProtParticlePickingPairs
+from xmipp3.protocols.protocol_preprocess_micrographs import XmippProtPreprocessMicrographs
+from xmipp3.protocols.protocol_projmatch import XmippProtProjMatch, XmippProjMatchViewer
+from xmipp3.protocols.protocol_random_conical_tilt import XmippProtRCT
+from xmipp3.protocols.protocol_ransac import XmippProtRansac
+from xmipp3.protocols.protocol_reconstruct_fourier import XmippProtReconstructFourier
+from xmipp3.protocols.protocol_reconstruct_highres import XmippProtReconstructHighRes
+from xmipp3.protocols.protocol_reconstruct_significant import XmippProtReconstructSignificant
+from xmipp3.protocols.protocol_reconstruct_swarm import XmippProtReconstructSwarm
+from xmipp3.protocols.protocol_resolution3d import XmippProtResolution3D
+from xmipp3.protocols.protocol_resolution_monogenic_signal import XmippProtMonoRes
+from xmipp3.protocols.protocol_rotational_spectra import XmippProtRotSpectra
+from xmipp3.protocols.protocol_rotational_symmetry import XmippProtRotationalSymmetry
+from xmipp3.protocols.protocol_screen_particles import XmippProtScreenParticles
+from xmipp3.protocols.protocol_solid_angles import XmippProtSolidAngles
+from xmipp3.protocols.protocol_split_volume import XmippProtSplitvolume
+from xmipp3.protocols.protocol_trigger_data import XmippProtTriggerData
+from xmipp3.protocols.protocol_validate_nontilt import XmippProtValidateNonTilt
+from xmipp3.protocols.protocol_validate_overfitting import XmippProtValidateOverfitting
+# from xmipp3.protocols.protocol_validate_tilt import XmippProtValidateTilt
+from xmipp3.protocols.protocol_volume_strain import XmippProtVolumeStrain
+from xmipp3.protocols.protocol_volume_homogenizer import XmippProtVolumeHomogenizer
+from xmipp3.protocols.protocol_write_testC import XmippProtWriteTestC
+from xmipp3.protocols.protocol_write_testP import XmippProtWriteTestP
+from xmipp3.protocols.protocol_ctf_selection import XmippProtCTFSelection
+#AJ
+from xmipp3.protocols.protocol_realignment_classes import XmippProtReAlignClasses

--- a/xmipp3/protocols/nma/__init__.py
+++ b/xmipp3/protocols/nma/__init__.py
@@ -24,13 +24,13 @@
 # *
 # **************************************************************************
 
-from protocol_nma import XmippProtNMA
-from protocol_nma_alignment import XmippProtAlignmentNMA
-from protocol_nma_base import NMA_CUTOFF_ABS, NMA_CUTOFF_REL
-#from protocol_nma_choose import XmippProtNMAChoose
-from protocol_nma_dimred import XmippProtDimredNMA
-from protocol_batch_cluster import BatchProtNMACluster
-from protocol_structure_mapping import XmippProtStructureMapping
+from xmipp3.protocols.nma.protocol_nma import XmippProtNMA
+from xmipp3.protocols.nma.protocol_nma_alignment import XmippProtAlignmentNMA
+from xmipp3.protocols.nma.protocol_nma_base import NMA_CUTOFF_ABS, NMA_CUTOFF_REL
+#from xmipp3.protocols.nma.protocol_nma_choose import XmippProtNMAChoose
+from xmipp3.protocols.nma.protocol_nma_dimred import XmippProtDimredNMA
+from xmipp3.protocols.nma.protocol_batch_cluster import BatchProtNMACluster
+from xmipp3.protocols.nma.protocol_structure_mapping import XmippProtStructureMapping
 
 from viewer_nma import XmippNMAViewer
 from viewer_nma_alignment import XmippAlignmentNMAViewer

--- a/xmipp3/protocols/nma/convert.py
+++ b/xmipp3/protocols/nma/convert.py
@@ -29,7 +29,7 @@ from collections import OrderedDict
 
 from pyworkflow.utils import Environ
 from pyworkflow.em.data import NormalMode
-from pyworkflow.em.packages.xmipp3.convert import rowToObject, objectToRow
+from xmipp3.convert import rowToObject, objectToRow
 import xmipp
 
             
@@ -56,7 +56,7 @@ def modeToRow(mode, row):
     
 def getNMAEnviron():
     """ Create the needed environment for NMA programs. """
-    from pyworkflow.em.packages.xmipp3 import getEnviron
-    environ = getEnviron()
+    from xmipp3 import Plugin
+    environ = Plugin.getEnviron()
     environ.update({'PATH': os.environ['NMA_HOME']}, position=Environ.BEGIN)
     return environ

--- a/xmipp3/protocols/nma/gui/matplotlib_point_path.py
+++ b/xmipp3/protocols/nma/gui/matplotlib_point_path.py
@@ -25,7 +25,7 @@
 # **************************************************************************
 
 from math import sqrt
-from pyworkflow.em.packages.xmipp3.nma.plotter import plotArray2D
+from xmipp3.protocols.nma.plotter import plotArray2D
 
 
 STATE_NO_POINTS = 0 # on points have been selected, double-click will add first one

--- a/xmipp3/protocols/nma/gui/matplotlib_point_selector.py
+++ b/xmipp3/protocols/nma/gui/matplotlib_point_selector.py
@@ -24,7 +24,7 @@
 # *
 # **************************************************************************
 
-from pyworkflow.em.packages.xmipp3.nma.plotter import plotArray2D
+from xmipp3.protocols.nma.plotter import plotArray2D
 
 
         

--- a/xmipp3/protocols/nma/gui/tk_clustering.py
+++ b/xmipp3/protocols/nma/gui/tk_clustering.py
@@ -30,9 +30,9 @@ import Tkinter as tk
 import pyworkflow.gui as gui
 from pyworkflow.gui.widgets import Button, HotButton
 
-from pyworkflow.em.packages.xmipp3.nma.data import Point
-from pyworkflow.em.packages.xmipp3.nma.gui import PointSelector 
-from pyworkflow.em.packages.xmipp3.nma.plotter import XmippNmaPlotter
+from xmipp3.protocols.nma.data import Point
+from xmipp3.protocols.nma.gui import PointSelector
+from xmipp3.protocols.nma.plotter import XmippNmaPlotter
 
  
     

--- a/xmipp3/protocols/nma/gui/tk_trajectories.py
+++ b/xmipp3/protocols/nma/gui/tk_trajectories.py
@@ -31,9 +31,9 @@ import pyworkflow.gui as gui
 from pyworkflow.utils.properties import Icon
 from pyworkflow.gui.widgets import Button, HotButton
 
-from pyworkflow.em.packages.xmipp3.nma.data import Point, PathData
-from pyworkflow.em.packages.xmipp3.nma.gui import PointPath
-from pyworkflow.em.packages.xmipp3.nma.plotter import XmippNmaPlotter
+from xmipp3.protocols.nma.data import Point, PathData
+from xmipp3.protocols.nma.gui import PointPath
+from xmipp3.protocols.nma.plotter import XmippNmaPlotter
 
  
     

--- a/xmipp3/protocols/nma/plotter.py
+++ b/xmipp3/protocols/nma/plotter.py
@@ -25,7 +25,7 @@
 # **************************************************************************
 
 import numpy as np
-from pyworkflow.em.packages.xmipp3.plotter import XmippPlotter
+from xmipp3.viewers.plotter import XmippPlotter
 
 
 class XmippNmaPlotter(XmippPlotter):

--- a/xmipp3/protocols/nma/protocol_batch_cluster.py
+++ b/xmipp3/protocols/nma/protocol_batch_cluster.py
@@ -28,7 +28,7 @@
 from pyworkflow.protocol.params import PointerParam, FileParam
 from pyworkflow.em.protocol import BatchProtocol
 from pyworkflow.em.data import SetOfParticles, Volume
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 
 
 

--- a/xmipp3/protocols/nma/protocol_nma.py
+++ b/xmipp3/protocols/nma/protocol_nma.py
@@ -36,10 +36,10 @@ from pyworkflow.utils.path import copyFile, createLink, makePath, cleanPath, mov
 from pyworkflow.protocol.params import (PointerParam, IntParam, FloatParam, 
                                         LEVEL_ADVANCED)
 from pyworkflow.em.data import SetOfNormalModes
-from pyworkflow.em.packages.xmipp3 import XmippMdRow
+from xmipp3.base import XmippMdRow
 import xmipp
-from protocol_nma_base import XmippProtNMABase, NMA_CUTOFF_REL
-from convert import rowToMode, getNMAEnviron
+from xmipp3.protocols.nma.protocol_nma_base import XmippProtNMABase, NMA_CUTOFF_REL
+from xmipp3.protocols.nma.convert import rowToMode, getNMAEnviron
         
 class XmippProtNMA(XmippProtNMABase):
     """ Flexible angular alignment using normal modes """

--- a/xmipp3/protocols/nma/protocol_nma_alignment.py
+++ b/xmipp3/protocols/nma/protocol_nma_alignment.py
@@ -35,13 +35,13 @@ from pyworkflow.utils import isPower2, getListFromRangeString
 from pyworkflow.utils.path import copyFile, cleanPath 
 import pyworkflow.protocol.params as params
 from pyworkflow.em.protocol import ProtAnalysis3D
-from pyworkflow.em.packages.xmipp3 import XmippMdRow
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles,\
-     xmippToLocation, getImageLocation, createItemMatrix, setXmippAttributes
+from xmipp3.base import XmippMdRow
+from xmipp3.convert import (writeSetOfParticles, xmippToLocation,
+                         getImageLocation, createItemMatrix, setXmippAttributes)
 from pyworkflow.protocol.params import NumericRangeParam
 import pyworkflow.em as em
 
-from convert import modeToRow
+from xmipp3.protocols.nma.convert import modeToRow
 
 import pyworkflow.em.metadata as md
 

--- a/xmipp3/protocols/nma/protocol_nma_base.py
+++ b/xmipp3/protocols/nma/protocol_nma_base.py
@@ -37,7 +37,7 @@ from pyworkflow.utils import *
 from pyworkflow.utils.path import copyFile, createLink, makePath, cleanPath, moveFile
 from pyworkflow.protocol.params import PointerParam, IntParam, FloatParam, LEVEL_ADVANCED, EnumParam
 from pyworkflow.protocol.constants import LEVEL_ADVANCED, LEVEL_ADVANCED
-from convert import getNMAEnviron
+from xmipp3.protocols.nma.convert import getNMAEnviron
 import xmipp
 
 #from xmipp3 import XmippProtocol

--- a/xmipp3/protocols/nma/protocol_nma_choose.py
+++ b/xmipp3/protocols/nma/protocol_nma_choose.py
@@ -24,8 +24,8 @@
 # *
 # **************************************************************************
 
-from protocol_convert_to_pseudoatoms_base import *
-from protocol_nma_base import *
+from xmipp3.protocols.protocol_convert_to_pseudoatoms_base import *
+from xmipp3.protocols.protocol_nma_base import *
 from pyworkflow.utils.path import createLink, cleanPath
 from pyworkflow.protocol.params import BooleanParam
 from xmipp import MetaData, MDL_NMA, MDL_ENABLED, MDL_NMA_MINRANGE, \

--- a/xmipp3/protocols/nma/protocol_structure_mapping.py
+++ b/xmipp3/protocols/nma/protocol_structure_mapping.py
@@ -26,22 +26,23 @@
 # **************************************************************************
 
 import os
-from glob import glob
+# from glob import glob
 import numpy as np
 import pyworkflow.em.metadata as md
 import pyworkflow.em as em
 from pyworkflow.em.protocol import EMProtocol
 import pyworkflow.protocol.params as params
 from pyworkflow import VERSION_1_1
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 from pyworkflow.protocol.constants import LEVEL_ADVANCED, STEPS_PARALLEL
 from pyworkflow.utils.path import cleanPattern, createLink, moveFile, copyFile, makePath, cleanPath
-from pyworkflow.object import String
-from pyworkflow.em.data import SetOfNormalModes
-from pyworkflow.em.packages.xmipp3 import XmippMdRow
-from pyworkflow.em.packages.xmipp3.pdb.protocol_pseudoatoms_base import XmippProtConvertToPseudoAtomsBase
+# from pyworkflow.object import String
+# from pyworkflow.em.data import SetOfNormalModes
+# from xmipp3.base import XmippMdRow
+from xmipp3.protocols.pdb.protocol_pseudoatoms_base import XmippProtConvertToPseudoAtomsBase
+from xmipp3.protocols.nma.protocol_nma_base import XmippProtNMABase, NMA_CUTOFF_REL
 import xmipp
-from pyworkflow.em.packages.xmipp3.nma.protocol_nma_base import XmippProtNMABase, NMA_CUTOFF_REL
+
 
 def mds(d, dimensions = 2):
     """

--- a/xmipp3/protocols/nma/viewer_nma.py
+++ b/xmipp3/protocols/nma/viewer_nma.py
@@ -32,7 +32,7 @@ from pyworkflow.gui.project import ProjectWindow
 from pyworkflow.protocol.params import LabelParam, IntParam
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import ObjectView, VmdView
-from protocol_nma import XmippProtNMA
+from xmipp3.protocols.nma.protocol_nma import XmippProtNMA
 from plotter import XmippNmaPlotter
 import xmipp
 

--- a/xmipp3/protocols/nma/viewer_nma_alignment.py
+++ b/xmipp3/protocols/nma/viewer_nma_alignment.py
@@ -34,7 +34,7 @@ from os.path import join, dirname, basename
 from pyworkflow.viewer import (ProtocolViewer, CommandView,
                                DESKTOP_TKINTER, WEB_DJANGO)
 from pyworkflow.protocol.params import StringParam, BooleanParam
-from protocol_nma_alignment import XmippProtAlignmentNMA
+from xmipp3.protocols.nma.protocol_nma_alignment import XmippProtAlignmentNMA
 from data import Point, Data
 import xmipp
 

--- a/xmipp3/protocols/nma/viewer_nma_dimred.py
+++ b/xmipp3/protocols/nma/viewer_nma_dimred.py
@@ -23,7 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-from pyworkflow.em.packages.xmipp3.nma.data import PathData
+from xmipp3.protocols.nma.data import PathData
 """
 This module implement the wrappers aroung Xmipp CL2D protocol
 visualization program.
@@ -40,7 +40,7 @@ from pyworkflow.utils.process import runJob
 from pyworkflow.em.viewer import VmdView
 from pyworkflow.gui.browser import FileBrowserWindow
 
-from protocol_nma_dimred import XmippProtDimredNMA, DIMRED_MAPPINGS
+from xmipp3.protocols.nma.protocol_nma_dimred import XmippProtDimredNMA, DIMRED_MAPPINGS
 from data import Point, Data
 from plotter import XmippNmaPlotter
 from gui import ClusteringWindow, TrajectoriesWindow
@@ -167,7 +167,7 @@ class XmippDimredNMAViewer(ProtocolViewer):
         partSet.write()
         partSet.close()
                 
-        from protocol_batch_cluster import BatchProtNMACluster
+        from xmipp3.protocols.protocol_batch_cluster import BatchProtNMACluster
         newProt = project.newProtocol(BatchProtNMACluster)
         clusterName = self.clusterWindow.getClusterName()
         if clusterName:

--- a/xmipp3/protocols/nma/viewer_structure_mapping.py
+++ b/xmipp3/protocols/nma/viewer_structure_mapping.py
@@ -27,7 +27,7 @@
 
 import os
 from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO, ProtocolViewer
-from protocol_structure_mapping import XmippProtStructureMapping
+from xmipp3.protocols.nma.protocol_structure_mapping import XmippProtStructureMapping
 from pyworkflow.gui.plotter import plt
 import numpy as np
 from mpl_toolkits.mplot3d import proj3d

--- a/xmipp3/protocols/pdb/__init__.py
+++ b/xmipp3/protocols/pdb/__init__.py
@@ -24,9 +24,9 @@
 # *
 # **************************************************************************
 
-from protocol_convert_pdb import XmippProtConvertPdb
-from protocol_combine_pdb import XmippProtCombinePdb
-from protocol_pseudoatoms import XmippProtConvertToPseudoAtoms
+from xmipp3.protocols.pdb.protocol_convert_pdb import XmippProtConvertPdb
+from xmipp3.protocols.pdb.protocol_combine_pdb import XmippProtCombinePdb
+from xmipp3.protocols.pdb.protocol_pseudoatoms import XmippProtConvertToPseudoAtoms
 
 from viewer_pseudoatoms import XmippPseudoAtomsViewer
 from viewer_combine_pdb import XmippProtCombinePdbViewer

--- a/xmipp3/protocols/pdb/protocol_pseudoatoms.py
+++ b/xmipp3/protocols/pdb/protocol_pseudoatoms.py
@@ -29,8 +29,8 @@
 
 from pyworkflow.protocol.params import PointerParam
 from pyworkflow.em.data import PdbFile, Volume
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
-from protocol_pseudoatoms_base import XmippProtConvertToPseudoAtomsBase
+from xmipp3.convert import getImageLocation
+from xmipp3.protocols.pdb.protocol_pseudoatoms_base import XmippProtConvertToPseudoAtomsBase
 from pyworkflow.em.data import Transform
 from pyworkflow.em.viewers.chimera_utils import \
     createCoordinateAxisFile

--- a/xmipp3/protocols/pdb/protocol_pseudoatoms_base.py
+++ b/xmipp3/protocols/pdb/protocol_pseudoatoms_base.py
@@ -34,7 +34,7 @@ from pyworkflow.utils.path import cleanPattern, createLink, moveFile
 from pyworkflow.protocol.params import EnumParam, PointerParam, FloatParam
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pyworkflow.em.protocol import Prot3D
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 from pyworkflow.em.viewers.chimera_utils import \
     createCoordinateAxisFile
 import os

--- a/xmipp3/protocols/pdb/viewer_combine_pdb.py
+++ b/xmipp3/protocols/pdb/viewer_combine_pdb.py
@@ -26,9 +26,9 @@
 # **************************************************************************
 
 from pyworkflow.em.viewer import DataView, ChimeraView
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.viewers import XmippViewer
 
-from protocol_combine_pdb import XmippProtCombinePdb
+from xmipp3.protocols.pdb.protocol_combine_pdb import XmippProtCombinePdb
 
 
 class XmippProtCombinePdbViewer(XmippViewer):

--- a/xmipp3/protocols/pdb/viewer_pseudoatoms.py
+++ b/xmipp3/protocols/pdb/viewer_pseudoatoms.py
@@ -28,9 +28,9 @@
 # **************************************************************************
 
 from pyworkflow.em.viewer import DataView, ChimeraView
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.viewers import XmippViewer
 
-from protocol_pseudoatoms import XmippProtConvertToPseudoAtoms
+from xmipp3.protocols.pdb.protocol_pseudoatoms import XmippProtConvertToPseudoAtoms
 
 
 

--- a/xmipp3/protocols/protocol_align_volume.py
+++ b/xmipp3/protocols/protocol_align_volume.py
@@ -27,7 +27,7 @@ import time
 
 import pyworkflow.protocol.params as params
 import pyworkflow.em as em
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 import numpy as np
 
 

--- a/xmipp3/protocols/protocol_apply_alignment.py
+++ b/xmipp3/protocols/protocol_apply_alignment.py
@@ -31,7 +31,7 @@ import pyworkflow.protocol.params as params
 
 from pyworkflow.em.convert import ImageHandler
 from pyworkflow.utils.properties import Message
-from convert import (xmippToLocation, writeSetOfParticles)
+from xmipp3.convert import (xmippToLocation, writeSetOfParticles)
 
         
 class XmippProtApplyAlignment(em.ProtAlign2D):

--- a/xmipp3/protocols/protocol_apply_transformation_matrix.py
+++ b/xmipp3/protocols/protocol_apply_transformation_matrix.py
@@ -26,7 +26,7 @@
 from pyworkflow import VERSION_1_1
 from pyworkflow.em.protocol import ProtProcessParticles
 import pyworkflow.protocol.params as params
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 import numpy as np
 
         

--- a/xmipp3/protocols/protocol_assignment_tilt_pair.py
+++ b/xmipp3/protocols/protocol_assignment_tilt_pair.py
@@ -32,10 +32,10 @@ from pyworkflow.utils.path import makePath, removeBaseExt
 from pyworkflow.em.data import SetOfParticles
 from pyworkflow.em.data_tiltpairs import TiltPair, CoordinatesTiltPair
 
-from convert import readAnglesFromMicrographs
-from protocol_particle_pick_pairs import XmippProtParticlePickingPairs
+from xmipp3.convert import readAnglesFromMicrographs
+from xmipp3.protocols.protocol_particle_pick_pairs import XmippProtParticlePickingPairs
 
-from convert import readSetOfCoordinates, writeSetOfCoordinates
+from xmipp3.convert import readSetOfCoordinates, writeSetOfCoordinates
 
 TYPE_COORDINATES = 0
 TYPE_PARTICLES = 1

--- a/xmipp3/protocols/protocol_break_symmetry.py
+++ b/xmipp3/protocols/protocol_break_symmetry.py
@@ -27,7 +27,7 @@
 from pyworkflow.object import String
 from pyworkflow.protocol.params import StringParam
 from pyworkflow.em.protocol import ProtProcessParticles
-from convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 import pyworkflow.em.metadata as md
 
  
@@ -125,7 +125,7 @@ class XmippProtAngBreakSymmetry(ProtProcessParticles):
 
     #--------------------------- Utils functions --------------------------------------------                
     def _createItemMatrix(self, item, row):
-        from pyworkflow.em.packages.xmipp3.convert import createItemMatrix
+        from xmipp3.convert import createItemMatrix
         import pyworkflow.em as em
         
         createItemMatrix(item, row, align=em.ALIGN_PROJ)

--- a/xmipp3/protocols/protocol_cl2d.py
+++ b/xmipp3/protocols/protocol_cl2d.py
@@ -33,7 +33,7 @@ import pyworkflow.protocol.params as param
 import pyworkflow.protocol.constants as const
 from pyworkflow.em.protocol import ProtClassify2D, SetOfClasses2D
 from pyworkflow.utils.path import cleanPath, makePath
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles, \
+from xmipp3.convert import writeSetOfParticles, \
     createItemMatrix, writeSetOfClasses2D, xmippToLocation, rowToAlignment
 
 # Comparison methods enum

--- a/xmipp3/protocols/protocol_cl2d_align.py
+++ b/xmipp3/protocols/protocol_cl2d_align.py
@@ -28,7 +28,7 @@ import pyworkflow.em as em
 import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 
-from convert import createItemMatrix, writeSetOfParticles, getImageLocation
+from xmipp3.convert import createItemMatrix, writeSetOfParticles, getImageLocation
 
 
 class XmippProtCL2DAlign(em.ProtAlign2D):

--- a/xmipp3/protocols/protocol_classification_gpuCorr.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr.py
@@ -29,9 +29,9 @@ import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 from pyworkflow.em.metadata.utils import iterRows, getSize
 from xmipp import MD_APPEND
-from pyworkflow.em.packages.xmipp3.convert import rowToAlignment, \
+from xmipp3.convert import rowToAlignment, \
     xmippToLocation
-from convert import writeSetOfParticles, writeSetOfClasses2D
+from xmipp3.convert import writeSetOfParticles, writeSetOfClasses2D
 from shutil import copy
 from os.path import join, exists
 from os import mkdir, remove, listdir

--- a/xmipp3/protocols/protocol_classification_gpuCorr_full.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr_full.py
@@ -30,7 +30,7 @@ import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 from pyworkflow.em.metadata.utils import iterRows, getSize
 from xmipp import Image, MD_APPEND, DT_DOUBLE
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles, \
+from xmipp3.convert import writeSetOfParticles, \
     xmippToLocation, rowToAlignment, rowToParticle
 from shutil import copy, copytree
 from os.path import exists, getmtime

--- a/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
+++ b/xmipp3/protocols/protocol_classification_gpuCorr_semi.py
@@ -31,7 +31,7 @@ from pyworkflow.em.protocol import ProtAlign2D
 import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 from pyworkflow.em.metadata.utils import iterRows
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles, \
+from xmipp3.convert import writeSetOfParticles, \
     rowToAlignment, writeSetOfClasses2D
 from os.path import getmtime
 from datetime import datetime

--- a/xmipp3/protocols/protocol_cltomo.py
+++ b/xmipp3/protocols/protocol_cltomo.py
@@ -25,11 +25,11 @@
 # **************************************************************************
 
 from pyworkflow.em import *  
-from constants import *
-from convert import writeSetOfVolumes, readSetOfClassesVol, readSetOfVolumes
+from xmipp3.constants import *
+from xmipp3.convert import writeSetOfVolumes, readSetOfClassesVol, readSetOfVolumes
 
 from xmipp import MetaData
-from xmipp3 import getEnviron
+from xmipp3 import Plugin
 
 
 class XmippProtCLTomo(ProtClassify3D):
@@ -181,7 +181,7 @@ class XmippProtCLTomo(ProtClassify3D):
 
     #--------------------------- UTILS functions --------------------------------------------
     def getCLTomoEnviron(self):
-        env = getEnviron()
+        env = Plugin.getEnviron()
         env.set('PYTHONPATH', os.path.join(os.environ['SCIPION_HOME'], 'software','lib','python2.7','site-packages','sh_alignment'),
                 Environ.BEGIN)
         return env

--- a/xmipp3/protocols/protocol_compare_angles.py
+++ b/xmipp3/protocols/protocol_compare_angles.py
@@ -33,13 +33,13 @@ from pyworkflow.utils.path import makePath
 from pyworkflow.em.convert import ImageHandler, ALIGN_PROJ
 from pyworkflow.em.data import Image
 from pyworkflow.em.protocol import ProtAnalysis3D
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 import pyworkflow.em.metadata as md
 
 import xmipp
-from convert import rowToAlignment, setXmippAttributes, xmippToLocation
+from xmipp3.convert import rowToAlignment, setXmippAttributes, xmippToLocation
 from xmipp3 import findRow
-from constants import SYM_URL
+from xmipp3.constants import SYM_URL
 
 
 class XmippProtCompareAngles(ProtAnalysis3D):

--- a/xmipp3/protocols/protocol_compare_reprojections.py
+++ b/xmipp3/protocols/protocol_compare_reprojections.py
@@ -34,13 +34,13 @@ from pyworkflow.em.constants import ALIGN_PROJ
 from pyworkflow.utils.path import cleanPath
 from pyworkflow.em.protocol import ProtAnalysis3D
 from pyworkflow.em.data import SetOfClasses2D, Image, SetOfAverages, SetOfParticles, Class2D
-from pyworkflow.em.packages.xmipp3.convert import setXmippAttributes, xmippToLocation
+from xmipp3.convert import setXmippAttributes, xmippToLocation
 import pyworkflow.em.metadata as md
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 
 import xmipp
 from xmipp3 import ProjMatcher
-from pyworkflow.em.packages.xmipp3.convert import rowToAlignment
+from xmipp3.convert import rowToAlignment
 
         
 class XmippProtCompareReprojections(ProtAnalysis3D, ProjMatcher):
@@ -99,7 +99,7 @@ class XmippProtCompareReprojections(ProtAnalysis3D, ProjMatcher):
 
     #--------------------------- STEPS functions ---------------------------------------------------
     def convertStep(self, imgsFn):
-        from convert import writeSetOfClasses2D, writeSetOfParticles
+        from xmipp3.convert import writeSetOfClasses2D, writeSetOfParticles
         imgSet = self.inputSet.get()
         if isinstance(imgSet, SetOfClasses2D):
             writeSetOfClasses2D(imgSet, self.imgsFn, writeParticles=True)

--- a/xmipp3/protocols/protocol_create_gallery.py
+++ b/xmipp3/protocols/protocol_create_gallery.py
@@ -28,7 +28,7 @@ import pyworkflow
 import pyworkflow.object as pwobj
 from pyworkflow.em import *  
 from xmipp import MetaData, MDL_ANGLE_ROT, MDL_ANGLE_TILT
-from pyworkflow.em.packages.xmipp3.convert import readSetOfParticles
+from xmipp3.convert import readSetOfParticles
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 
 

--- a/xmipp3/protocols/protocol_ctf_correct_wiener2d.py
+++ b/xmipp3/protocols/protocol_ctf_correct_wiener2d.py
@@ -28,7 +28,7 @@ import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 
 from pyworkflow.em.protocol import ProtProcessParticles
-from pyworkflow.em.packages.xmipp3.convert import (writeSetOfParticles, xmippToLocation)
+from xmipp3.convert import (writeSetOfParticles, xmippToLocation)
 
 
 class XmippProtCTFCorrectWiener2D(ProtProcessParticles):

--- a/xmipp3/protocols/protocol_ctf_defocus_group.py
+++ b/xmipp3/protocols/protocol_ctf_defocus_group.py
@@ -29,7 +29,7 @@ This file implements CTF defocus groups using xmipp 3.1
 """
 from pyworkflow.em import *  
 from pyworkflow.utils import *  
-from convert import writeSetOfParticles, writeSetOfDefocusGroups
+from xmipp3.convert import writeSetOfParticles, writeSetOfDefocusGroups
 import xmipp
 from math import pi
 from pyworkflow.protocol.params import GE

--- a/xmipp3/protocols/protocol_ctf_discrepancy.py
+++ b/xmipp3/protocols/protocol_ctf_discrepancy.py
@@ -27,7 +27,7 @@
 # **************************************************************************
 
 import os
-import convert
+import xmipp3.convert
 import xmipp
 from pyworkflow.em.data import SetOfCTF
 from pyworkflow.object import Set, Float

--- a/xmipp3/protocols/protocol_ctf_micrographs.py
+++ b/xmipp3/protocols/protocol_ctf_micrographs.py
@@ -37,8 +37,8 @@ import pyworkflow.protocol.params as params
 import pyworkflow.protocol.constants as pwconst
 import pyworkflow.utils as pwutils
 
-from pyworkflow.em.packages.xmipp3.utils import isMdEmpty
-from pyworkflow.em.packages.xmipp3.convert import mdToCTFModel, readCTFModel
+from xmipp3.utils import isMdEmpty
+from xmipp3.convert import mdToCTFModel, readCTFModel
 
 class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
     """ Protocol to estimate CTF on a set of micrographs using Xmipp. """

--- a/xmipp3/protocols/protocol_denoise_particles.py
+++ b/xmipp3/protocols/protocol_denoise_particles.py
@@ -30,7 +30,7 @@ from pyworkflow.object import String
 from pyworkflow.protocol.params import IntParam, PointerParam, LEVEL_ADVANCED
 from pyworkflow.em.protocol import ProtProcessParticles
 
-from convert import writeSetOfParticles, writeSetOfClasses2D, xmippToLocation
+from xmipp3.convert import writeSetOfParticles, writeSetOfClasses2D, xmippToLocation
 
 
         

--- a/xmipp3/protocols/protocol_eliminate_empty_particles.py
+++ b/xmipp3/protocols/protocol_eliminate_empty_particles.py
@@ -34,7 +34,7 @@ from pyworkflow.em.protocol import ProtClassify2D
 from pyworkflow.em.data import SetOfParticles
 from pyworkflow.object import Set
 from pyworkflow.utils.properties import Message
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles, \
+from xmipp3.convert import writeSetOfParticles, \
     readSetOfParticles, setXmippAttributes
 
 

--- a/xmipp3/protocols/protocol_extract_particles.py
+++ b/xmipp3/protocols/protocol_extract_particles.py
@@ -33,7 +33,7 @@ from os.path import exists, basename
 
 import pyworkflow.em.metadata as md
 import pyworkflow.utils as pwutils
-from pyworkflow.em.packages.xmipp3.constants import SAME_AS_PICKING, OTHER
+from xmipp3.constants import SAME_AS_PICKING, OTHER
 from pyworkflow.protocol.constants import (STEPS_PARALLEL, LEVEL_ADVANCED,
                                            STATUS_FINISHED)
 import pyworkflow.protocol.params as params
@@ -41,7 +41,7 @@ from pyworkflow.em.protocol import ProtExtractParticles
 from pyworkflow.em.data import Particle
 from pyworkflow.em.constants import RELATION_CTF
 
-from convert import (micrographToCTFParam, writeMicCoordinates, xmippToLocation,
+from xmipp3.convert import (micrographToCTFParam, writeMicCoordinates, xmippToLocation,
                      setXmippAttributes)
 from xmipp3 import XmippProtocol
 
@@ -450,7 +450,7 @@ class XmippProtExtractParticles(ProtExtractParticles, XmippProtocol):
         return self._getPath('images.xmd')
 
     def createParticles(self, item, row):
-        from pyworkflow.em.packages.xmipp3.convert import rowToParticle
+        from xmipp3.convert import rowToParticle
         
         particle = rowToParticle(row, readCtf=self._useCTF())
         coord = particle.getCoordinate()

--- a/xmipp3/protocols/protocol_extract_particles_movies.py
+++ b/xmipp3/protocols/protocol_extract_particles_movies.py
@@ -32,7 +32,7 @@ import os
 import pyworkflow.em.metadata as md
 
 from pyworkflow.em import SetOfCoordinates
-from pyworkflow.em.packages.xmipp3.convert import (readSetOfMovieParticles,
+from xmipp3.convert import (readSetOfMovieParticles,
                                                    xmippToLocation)
 from pyworkflow.em.convert import ImageHandler
 from pyworkflow.em.protocol import ProtExtractMovieParticles, ProtProcessMovies
@@ -42,7 +42,8 @@ from pyworkflow.protocol.params import (PointerParam, IntParam, BooleanParam,
 
 from pyworkflow.utils.path import cleanPath
 
-from pyworkflow.em.packages.xmipp3 import coordinateToRow, XmippMdRow
+from xmipp3.convert import coordinateToRow
+from xmipp3.base import XmippMdRow
 
 
 

--- a/xmipp3/protocols/protocol_extract_particles_pairs.py
+++ b/xmipp3/protocols/protocol_extract_particles_pairs.py
@@ -32,14 +32,14 @@ from os.path import exists
 
 import pyworkflow.em.metadata as md
 import pyworkflow.utils as pwutils
-from pyworkflow.em.packages.xmipp3 import XmippProtocol
-from pyworkflow.em.packages.xmipp3.constants import OTHER
+from xmipp3.base import XmippProtocol
+from xmipp3.constants import OTHER
 from pyworkflow.protocol.constants import (STEPS_PARALLEL, LEVEL_ADVANCED,
                                            STATUS_FINISHED)
 from pyworkflow.protocol.params import (PointerParam, EnumParam, FloatParam,
                                         IntParam, BooleanParam, Positive, GE)
 from pyworkflow.em.protocol import ProtExtractParticlesPair
-from convert import writeSetOfCoordinates, readSetOfParticles
+from xmipp3.convert import writeSetOfCoordinates, readSetOfParticles
 from pyworkflow.em.data_tiltpairs import ParticlesTiltPair, TiltPair
 from pyworkflow.em.data import SetOfMicrographs, SetOfParticles
 

--- a/xmipp3/protocols/protocol_extract_unit_cell.py
+++ b/xmipp3/protocols/protocol_extract_unit_cell.py
@@ -30,8 +30,8 @@ from pyworkflow.em.constants import SCIPION_SYM_NAME
 from pyworkflow.em.constants import SYM_I222, SYM_I222r, SYM_In25, SYM_In25r, \
     SYM_CYCLIC, SYM_DIHEDRAL, SYM_TETRAHEDRAL, SYM_OCTAHEDRAL
 from pyworkflow.em.data import Transform
-from pyworkflow.em.headers import Ccp4Header
-from pyworkflow.em.packages.xmipp3 import XMIPP_SYM_NAME
+from pyworkflow.em.convert_header.CCP4.convert import Ccp4Header
+from xmipp3.constants import XMIPP_SYM_NAME
 from pyworkflow.em.protocol import EMProtocol
 from pyworkflow.protocol.params import PointerParam, FloatParam, EnumParam, \
     IntParam

--- a/xmipp3/protocols/protocol_helical_parameters.py
+++ b/xmipp3/protocols/protocol_helical_parameters.py
@@ -29,7 +29,7 @@ import pyworkflow.object as pwobj
 from pyworkflow.em import *  
 from xmipp import MetaData, MDL_ANGLE_ROT, MDL_SHIFT_Z
 from xmipp3 import HelicalFinder
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 
 

--- a/xmipp3/protocols/protocol_kerdensom.py
+++ b/xmipp3/protocols/protocol_kerdensom.py
@@ -29,7 +29,7 @@ from pyworkflow.em import *
 import xmipp
 
 import xmipp3
-from convert import writeSetOfParticles, readSetOfClasses2D, xmippToLocation
+from xmipp3.convert import writeSetOfParticles, readSetOfClasses2D, xmippToLocation
 from glob import glob
 
 

--- a/xmipp3/protocols/protocol_ml2d.py
+++ b/xmipp3/protocols/protocol_ml2d.py
@@ -35,7 +35,7 @@ from pyworkflow.em.constants import ALIGN_2D
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pyworkflow.protocol.params import (PointerParam, BooleanParam, IntParam,
                                         FloatParam)
-from convert import writeSetOfParticles, rowToAlignment, xmippToLocation
+from xmipp3.convert import writeSetOfParticles, rowToAlignment, xmippToLocation
 
 
 

--- a/xmipp3/protocols/protocol_mltomo.py
+++ b/xmipp3/protocols/protocol_mltomo.py
@@ -32,11 +32,11 @@ from pyworkflow.em import ProtClassify3D, ALIGN_PROJ, Float
 from pyworkflow.em.data import SetOfVolumes, SetOfClassesVol
 from pyworkflow.em.constants import ALIGN_NONE
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
-from xmipp3 import getEnviron
+from xmipp3 import Plugin
 import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
-from convert import (readSetOfClassesVol, getImageLocation,
+from xmipp3.convert import (readSetOfClassesVol, getImageLocation,
                      writeSetOfVolumes, rowToAlignment)
 
 
@@ -481,14 +481,14 @@ class XmippProtMLTomo(ProtClassify3D):
 
     #--------------------------- UTILS functions ------------------------------
     def getMLTomoEnviron(self):
-        env = getEnviron()
+        env = Plugin.getEnviron()
         return env
 
     def isSetOfVolumes(self):
         return isinstance(self.inputRefVols.get(), SetOfVolumes)
 
     def _postprocessVolumeRow(self, img, imgRow):
-        # explicitly set this from protocol input
+        # explicitly set this from xmipp3.protocols.protocol input
         # to avoid conflict with input metadata
         missNum = self.missingDataType.get()
         imgRow.setValue(md.MDL_MISSINGREGION_NR, missNum + 1)

--- a/xmipp3/protocols/protocol_movie_average.py
+++ b/xmipp3/protocols/protocol_movie_average.py
@@ -30,7 +30,7 @@ import os
 import pyworkflow.protocol.params as params
 from pyworkflow import VERSION_1_1
 from pyworkflow.em.protocol import ProtAlignMovies
-from convert import writeMovieMd
+from xmipp3.convert import writeMovieMd
 
 CROP_NONE = 0
 CROP_ALIGNMENT = 1

--- a/xmipp3/protocols/protocol_movie_correlation.py
+++ b/xmipp3/protocols/protocol_movie_correlation.py
@@ -36,7 +36,7 @@ from pyworkflow import VERSION_1_1
 from pyworkflow.em.protocol import ProtAlignMovies
 from pyworkflow.em.protocol.protocol_align_movies import createAlignmentPlot
 import pyworkflow.em.metadata as md
-from convert import writeMovieMd
+from xmipp3.convert import writeMovieMd
 
 
 class XmippProtMovieCorr(ProtAlignMovies):
@@ -189,7 +189,7 @@ class XmippProtMovieCorr(ProtAlignMovies):
         return self._getExtraPath(self._getMovieRoot(movie) + '_shifts.xmd')
 
     def _getMovieShifts(self, movie):
-        from convert import readShiftsMovieAlignment
+        from xmipp3.convert import readShiftsMovieAlignment
         """ Returns the x and y shifts for the alignment of this movie.
          The shifts should refer to the original micrograph without any binning.
          In case of a bining greater than 1, the shifts should be scaled.

--- a/xmipp3/protocols/protocol_movie_opticalflow.py
+++ b/xmipp3/protocols/protocol_movie_opticalflow.py
@@ -38,7 +38,7 @@ from pyworkflow.em.protocol import ProtAlignMovies
 from pyworkflow.em.protocol.protocol_align_movies import createAlignmentPlot
 import pyworkflow.protocol.params as params
 import pyworkflow.em.metadata as md
-from convert import writeMovieMd
+from xmipp3.convert import writeMovieMd
 
 PLOT_CART = 0
 PLOT_POLAR = 1

--- a/xmipp3/protocols/protocol_multiple_fscs.py
+++ b/xmipp3/protocols/protocol_multiple_fscs.py
@@ -29,7 +29,7 @@ import pyworkflow.protocol.params as params
 
 import pyworkflow.em as em
 import pyworkflow.em.metadata as md
-from convert import locationToXmipp
+from xmipp3.convert import locationToXmipp
 
 
 class XmippProtMultipleFSCs(em.ProtAnalysis3D):

--- a/xmipp3/protocols/protocol_multireference_alignability.py
+++ b/xmipp3/protocols/protocol_multireference_alignability.py
@@ -37,7 +37,7 @@ from pyworkflow.utils.path import moveFile, makePath
 from pyworkflow.gui.plotter import Plotter
 
 
-from pyworkflow.em.packages.xmipp3.convert import (writeSetOfParticles,
+from xmipp3.convert import (writeSetOfParticles,
                                                    writeSetOfVolumes,
                                                    getImageLocation)
 

--- a/xmipp3/protocols/protocol_particle_pick.py
+++ b/xmipp3/protocols/protocol_particle_pick.py
@@ -31,7 +31,7 @@ from pyworkflow.utils.path import *
 import xmipp
 from xmipp3 import XmippProtocol
 from pyworkflow.em.showj import launchSupervisedPickerGUI
-from convert import writeSetOfMicrographs, readSetOfCoordinates
+from xmipp3.convert import writeSetOfMicrographs, readSetOfCoordinates
 
 
 class XmippProtParticlePicking(ProtParticlePicking, XmippProtocol):

--- a/xmipp3/protocols/protocol_particle_pick_automatic.py
+++ b/xmipp3/protocols/protocol_particle_pick_automatic.py
@@ -30,7 +30,7 @@ from pyworkflow.utils.path import *
 import xmipp
 from xmipp3 import XmippProtocol
 
-from convert import readSetOfCoordinates
+from xmipp3.convert import readSetOfCoordinates
 
 
 MICS_SAMEASPICKING = 0

--- a/xmipp3/protocols/protocol_particle_pick_pairs.py
+++ b/xmipp3/protocols/protocol_particle_pick_pairs.py
@@ -33,7 +33,7 @@ from pyworkflow.em.data_tiltpairs import CoordinatesTiltPair
 from pyworkflow.em.showj import launchTiltPairPickerGUI
 
 from xmipp3 import XmippProtocol
-import convert
+import xmipp3.convert
 
 
 

--- a/xmipp3/protocols/protocol_preprocess/__init__.py
+++ b/xmipp3/protocols/protocol_preprocess/__init__.py
@@ -24,31 +24,31 @@
 # *
 # **************************************************************************
 
-from protocol_crop_resize import XmippResizeHelper
-from protocol_crop_resize import XmippProtCropResizeParticles
-from protocol_crop_resize import XmippProtCropResizeVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_crop_resize import XmippResizeHelper
+from xmipp3.protocols.protocol_preprocess.protocol_crop_resize import XmippProtCropResizeParticles
+from xmipp3.protocols.protocol_preprocess.protocol_crop_resize import XmippProtCropResizeVolumes
 
-from protocol_filter import XmippFilterHelper
-from protocol_filter import XmippProtFilterParticles
-from protocol_filter import XmippProtFilterVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_filter import XmippFilterHelper
+from xmipp3.protocols.protocol_preprocess.protocol_filter import XmippProtFilterParticles
+from xmipp3.protocols.protocol_preprocess.protocol_filter import XmippProtFilterVolumes
 
-from protocol_mask import XmippProtMaskParticles
-from protocol_mask import XmippProtMaskVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_mask import XmippProtMaskParticles
+from xmipp3.protocols.protocol_preprocess.protocol_mask import XmippProtMaskVolumes
 
-from protocol_preprocess import XmippProtPreprocessParticles
-from protocol_preprocess import XmippProtPreprocessVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_preprocess import XmippProtPreprocessParticles
+from xmipp3.protocols.protocol_preprocess.protocol_preprocess import XmippProtPreprocessVolumes
 
-from protocol_image_operate import XmippOperateHelper
-from protocol_image_operate import XmippProtImageOperateParticles
-from protocol_image_operate import XmippProtImageOperateVolumes
-from protocol_image_operate import OP_PLUS, OP_MINUS, OP_MULTIPLY, \
+from xmipp3.protocols.protocol_preprocess.protocol_image_operate import XmippOperateHelper
+from xmipp3.protocols.protocol_preprocess.protocol_image_operate import XmippProtImageOperateParticles
+from xmipp3.protocols.protocol_preprocess.protocol_image_operate import XmippProtImageOperateVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_image_operate import OP_PLUS, OP_MINUS, OP_MULTIPLY, \
                                    OP_DIVIDE, OP_MINIMUM, OP_MAXIMUM, \
                                    OP_DOTPRODUCT, OP_LOG, OP_LOG10, \
                                    OP_SQRT, OP_ABS, OP_POW, OP_SLICE, \
                                    OP_COLUNM, OP_ROW, OP_RADIAL, OP_RESET
 
-from protocol_create_mask3d import XmippProtCreateMask3D
-from protocol_create_mask2d import XmippProtCreateMask2D
+from xmipp3.protocols.protocol_preprocess.protocol_create_mask3d import XmippProtCreateMask3D
+from xmipp3.protocols.protocol_preprocess.protocol_create_mask2d import XmippProtCreateMask2D
 
-from protocol_movie_resize import XmippProtMovieResize
+from xmipp3.protocols.protocol_preprocess.protocol_movie_resize import XmippProtMovieResize
 

--- a/xmipp3/protocols/protocol_preprocess/geometrical_mask.py
+++ b/xmipp3/protocols/protocol_preprocess/geometrical_mask.py
@@ -27,7 +27,7 @@
 
 from pyworkflow.protocol.params import (IntParam, EnumParam, FloatParam,
                                         BooleanParam)
-from ..constants import *
+from xmipp3.constants import *
 
 
 class XmippGeometricalMask3D:

--- a/xmipp3/protocols/protocol_preprocess/protocol_add_noise.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_add_noise.py
@@ -33,7 +33,7 @@ from pyworkflow.protocol.params import (PointerParam, EnumParam, FloatParam, LEV
 from pyworkflow.em.protocol.protocol_3d import ProtRefine3D
 from pyworkflow.em.data import Volume
 import pyworkflow.em as em
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles 
+from xmipp3.convert import writeSetOfParticles
 
 
 

--- a/xmipp3/protocols/protocol_preprocess/protocol_create_mask2d.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_create_mask2d.py
@@ -27,8 +27,8 @@
 # **************************************************************************
 
 from pyworkflow.em import *  
-from ..convert import getImageLocation
-from ..constants import *
+from xmipp3.convert import getImageLocation
+from xmipp3.constants import *
 from geometrical_mask import *
 
 SOURCE_PARTICLE=0

--- a/xmipp3/protocols/protocol_preprocess/protocol_create_mask3d.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_create_mask3d.py
@@ -28,8 +28,8 @@
 
 from pyworkflow.em import *  
 
-from ..convert import getImageLocation
-from ..constants import *
+from ...convert import getImageLocation
+from xmipp3.constants import *
 from geometrical_mask import *
 
 SOURCE_VOLUME=0

--- a/xmipp3/protocols/protocol_preprocess/protocol_crop_resize.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_crop_resize.py
@@ -30,7 +30,7 @@
 from pyworkflow.protocol.params import BooleanParam, EnumParam, FloatParam, IntParam
 from pyworkflow.em.data import Volume
 
-from protocol_process import XmippProcessParticles, XmippProcessVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_process import XmippProcessParticles, XmippProcessVolumes
 
 
 

--- a/xmipp3/protocols/protocol_preprocess/protocol_filter.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_filter.py
@@ -35,10 +35,10 @@ from pyworkflow.protocol.params import (
 from pyworkflow.em.data import ImageDim, CTFModel
 from pyworkflow.em.constants import FILTER_LOW_PASS, FILTER_HIGH_PASS, FILTER_BAND_PASS
 from pyworkflow.em.protocol import ProtFilterParticles, ProtFilterVolumes
-from pyworkflow.em.packages.xmipp3.constants import (
+from xmipp3.constants import (
     FILTER_SPACE_FOURIER, FILTER_SPACE_REAL, FILTER_SPACE_WAVELET)
-from protocol_process import XmippProcessParticles, XmippProcessVolumes
-from pyworkflow.em.packages.xmipp3.convert import writeCTFModel
+from xmipp3.protocols.protocol_preprocess.protocol_process import XmippProcessParticles, XmippProcessVolumes
+from xmipp3.convert import writeCTFModel
 
 
 

--- a/xmipp3/protocols/protocol_preprocess/protocol_image_operate.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_image_operate.py
@@ -33,8 +33,8 @@ from collections import OrderedDict
 from pyworkflow.em.constants import ALIGN_NONE
 import pyworkflow.protocol.params as params
 from pyworkflow.em.protocol import ProtOperateParticles, ProtOperateVolumes
-from protocol_process import XmippProcessParticles, XmippProcessVolumes
-from pyworkflow.em.packages.xmipp3.convert import (writeSetOfParticles,
+from xmipp3.protocols.protocol_preprocess.protocol_process import XmippProcessParticles, XmippProcessVolumes
+from xmipp3.convert import (writeSetOfParticles,
                                                    writeSetOfVolumes,
                                                    getImageLocation)
 

--- a/xmipp3/protocols/protocol_preprocess/protocol_mask.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_mask.py
@@ -29,12 +29,12 @@ from pyworkflow.em import *
 from pyworkflow.utils import *  
 # import xmipp
 from geometrical_mask import XmippGeometricalMask3D, XmippGeometricalMask2D
-from protocol_process import XmippProcessParticles, XmippProcessVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_process import XmippProcessParticles, XmippProcessVolumes
 from pyworkflow.em.constants import *
 
-from ..convert import getImageLocation
+from xmipp3.convert import getImageLocation
 
-from ..constants import *
+from xmipp3.constants import *
 
 
 class XmippProtMask():

--- a/xmipp3/protocols/protocol_preprocess/protocol_preprocess.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_preprocess.py
@@ -28,11 +28,11 @@
 from pyworkflow.em import *
 from pyworkflow.utils import *  
 from pyworkflow.protocol.params import *
-from protocol_process import XmippProcessParticles, XmippProcessVolumes
+from xmipp3.protocols.protocol_preprocess.protocol_process import XmippProcessParticles, XmippProcessVolumes
 from pyworkflow.utils.path import cleanPath
-from ..constants import *
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
-from ..convert import locationToXmipp, writeSetOfParticles
+from xmipp3.constants import *
+from xmipp3.convert import getImageLocation
+from ...convert import locationToXmipp, writeSetOfParticles
 from pyworkflow.em import Volume
 
 class XmippPreprocessHelper():

--- a/xmipp3/protocols/protocol_preprocess/protocol_process.py
+++ b/xmipp3/protocols/protocol_preprocess/protocol_process.py
@@ -27,8 +27,8 @@
 from pyworkflow.em.constants import ALIGN_NONE
 from pyworkflow.em.protocol import ProtProcessParticles, ProtPreprocessVolumes
 from pyworkflow.em.data import Volume
-from ..convert import writeSetOfParticles, xmippToLocation
-from ..convert import writeSetOfVolumes, getImageLocation
+from ...convert import writeSetOfParticles, xmippToLocation
+from ...convert import writeSetOfVolumes, getImageLocation
 import pyworkflow.em.metadata as md
 
 

--- a/xmipp3/protocols/protocol_projmatch/__init__.py
+++ b/xmipp3/protocols/protocol_projmatch/__init__.py
@@ -27,5 +27,5 @@
 This sub-package contains projection matching related utilities.
 """
 
-from protocol_projmatch import XmippProtProjMatch
+from xmipp3.protocols.protocol_projmatch.protocol_projmatch import XmippProtProjMatch
 from viewer_projmatch import XmippProjMatchViewer

--- a/xmipp3/protocols/protocol_projmatch/projmatch_form.py
+++ b/xmipp3/protocols/protocol_projmatch/projmatch_form.py
@@ -36,11 +36,10 @@ from pyworkflow.protocol.params import (PointerParam, BooleanParam, IntParam,
                                         EnumParam, NumericListParam, TextParam,
                                         DigFreqParam)
 
-from pyworkflow.em.packages.xmipp3.constants import SYM_URL
+from xmipp3.constants import *
                                         
 
 def _defineProjectionMatchingParams(self, form):
-    import pyworkflow.em.packages.xmipp3 as xmipp3
     
     form.addSection(label='Input')
     
@@ -121,7 +120,7 @@ def _defineProjectionMatchingParams(self, form):
     
     # doMask, doSphericalMask now merged into maskType
     
-    groupMask.addParam('maskType', EnumParam, choices=['None', 'circular', 'mask object'], default=xmipp3.MASK2D_CIRCULAR, 
+    groupMask.addParam('maskType', EnumParam, choices=['None', 'circular', 'mask object'], default=MASK2D_CIRCULAR,
                  label="Mask reference volumes", display=EnumParam.DISPLAY_COMBO,
                  help='Masking the reference volume will increase the signal to noise ratio. \n '
                       'Do not provide a very tight mask. \n ')
@@ -222,21 +221,21 @@ def _defineProjectionMatchingParams(self, form):
     
     # Changed from String to Int 
     form.addParam('projectionMethod', EnumParam, choices=['fourier', 'real_space'], 
-                 default=xmipp3.PROJECT_REALSPACE, expertLevel=LEVEL_ADVANCED, 
+                 default=PROJECT_REALSPACE, expertLevel=LEVEL_ADVANCED,
                  label="Projection method", display=EnumParam.DISPLAY_COMBO,
                  help='select projection method, by default Fourier with padding 1 and interpolation bspline')        
     
     
     form.addParam('paddingAngularProjection', FloatParam, default=1, expertLevel=LEVEL_ADVANCED,  
-                 condition='projectionMethod == %d' % xmipp3.PROJECT_FOURIER,
+                 condition='projectionMethod == %d' % PROJECT_FOURIER,
                  label='Padding factor for projection', validators=[GE(1)],
                  help="""Increase the padding factor will improve projection quality but 
     projection generation will be slower. In general padding 1 and spline is OK
     """)       
     # Changed from String to Int 
     form.addParam('kernelAngularProjection', EnumParam, choices=['neareast', 'linear', 'bspline'],
-                 default=xmipp3.KERNEL_BSPLINE, expertLevel=LEVEL_ADVANCED,  
-                 condition='projectionMethod == %d' % xmipp3.PROJECT_FOURIER,
+                 default=KERNEL_BSPLINE, expertLevel=LEVEL_ADVANCED,
+                 condition='projectionMethod == %d' % PROJECT_FOURIER,
                  label='Interpolation kernel for projection', 
                  help=""" Interpolation kernel for the generation of projections.
     """)
@@ -327,7 +326,7 @@ def _defineProjectionMatchingParams(self, form):
     
     form.addParam('discardImages', EnumParam, 
                  choices=['None', 'maxCC', 'percentage', 'classPercentage'],
-                 default=xmipp3.SELECT_NONE, display=EnumParam.DISPLAY_COMBO,
+                 default=SELECT_NONE, display=EnumParam.DISPLAY_COMBO,
                  label='Discard images?', 
                  help=""" 
     None : No images will be discarded.
@@ -338,7 +337,7 @@ def _defineProjectionMatchingParams(self, form):
     """)
     form.addParam('minimumCrossCorrelation', NumericListParam, default='0.1', 
                  label='discard image if CC below', 
-                 condition='discardImages==%d' % xmipp3.SELECT_MAXCC,
+                 condition='discardImages==%d' % SELECT_MAXCC,
                  help=""" 
     Discard images with cross-correlation (CC) below this value.
     Provide a sequence of numbers (for instance, "0.3 0.3 0.5 0.5" specifies 4 iterations,
@@ -350,7 +349,7 @@ def _defineProjectionMatchingParams(self, form):
     
     form.addParam('discardPercentage', NumericListParam, default='10', 
                  label='discard image percentage with less CC',
-                 condition='discardImages==%d'%xmipp3.SELECT_PERCENTAGE,
+                 condition='discardImages==%d'%SELECT_PERCENTAGE,
                  help=""" 
     Discard this percentage of images with less cross-correlation (CC)
     Provide a sequence of numbers (for instance, "20 20 10 10" specifies 4 iterations,
@@ -363,7 +362,7 @@ def _defineProjectionMatchingParams(self, form):
     
     form.addParam('discardPercentagePerClass', NumericListParam, default='10', 
                  label='discard image percentage in class with less CC',
-                 condition='discardImages==%d'%xmipp3.SELECT_CLASSPERCENTAGE,
+                 condition='discardImages==%d'%SELECT_CLASSPERCENTAGE,
                  help=""" 
     Discard this percentage of images in each class(projection direction)
     with less cross-correlation (CC)    
@@ -483,7 +482,7 @@ def _defineProjectionMatchingParams(self, form):
     
     form.addParam('reconstructionMethod', EnumParam, expertLevel=LEVEL_ADVANCED,
                  choices=['fourier', 'art', 'wbp'],
-                 default=xmipp3.RECONSTRUCT_FOURIER, display=EnumParam.DISPLAY_COMBO,
+                 default=RECONSTRUCT_FOURIER, display=EnumParam.DISPLAY_COMBO,
                  label='Reconstruction method', 
                  help=""" Select what reconstruction method to use.
     fourier: Fourier space interpolation (with griding).
@@ -492,20 +491,20 @@ def _defineProjectionMatchingParams(self, form):
     """)
     
     form.addParam('fourierMaxFrequencyOfInterest', DigFreqParam, default=0.25,
-                 condition='reconstructionMethod == %d' % xmipp3.RECONSTRUCT_FOURIER,
+                 condition='reconstructionMethod == %d' % RECONSTRUCT_FOURIER,
                  label='Initial maximum frequency', expertLevel=LEVEL_ADVANCED,
                  help=""" This number is only used in the first iteration. 
     From then on, it will be set to resolution computed in the resolution section
     """)         
     form.addParam('fourierReconstructionExtraCommand', StringParam, default='',
-                 condition='reconstructionMethod == %d' % xmipp3.RECONSTRUCT_FOURIER,
+                 condition='reconstructionMethod == %d' % RECONSTRUCT_FOURIER,
                  label='Additional parameters for fourier', expertLevel=LEVEL_ADVANCED,
                  help=""" For details see:
     [[http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Fourier][fourier]]
     """)          
     
     form.addParam('artLambda', NumericListParam, default='0.2', 
-                 condition='reconstructionMethod == %d' % xmipp3.RECONSTRUCT_ART,
+                 condition='reconstructionMethod == %d' % RECONSTRUCT_ART,
                  label='Values of lambda for ART', expertLevel=LEVEL_ADVANCED,
                  help=""" *IMPORTANT:* ou must specify a value of lambda for each iteration even
     if ART has not been selected.
@@ -524,14 +523,14 @@ def _defineProjectionMatchingParams(self, form):
     """)   
     
     form.addParam('artReconstructionExtraCommand', StringParam, default='-k 0.5 -n 10 ',
-                 condition='reconstructionMethod == %d' % xmipp3.RECONSTRUCT_ART,
+                 condition='reconstructionMethod == %d' % RECONSTRUCT_ART,
                  label='Additional parameters for ART', expertLevel=LEVEL_ADVANCED,
                  help=""" For details see:
     [[http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Art][xmipp art]]
     """)          
     
     form.addParam('wbpReconstructionExtraCommand', StringParam, default='',
-                 condition='reconstructionMethod == %d' % xmipp3.RECONSTRUCT_WBP,
+                 condition='reconstructionMethod == %d' % RECONSTRUCT_WBP,
                  label='Additional parameters for WBP', expertLevel=LEVEL_ADVANCED,
                  help=""" For details see:
     [[http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Wbp][xmipp wbp]]

--- a/xmipp3/protocols/protocol_projmatch/projmatch_steps.py
+++ b/xmipp3/protocols/protocol_projmatch/projmatch_steps.py
@@ -38,8 +38,8 @@ from pyworkflow.object import Float
 from pyworkflow.em.data import Volume, SetOfClasses3D
 from pyworkflow.utils import getMemoryAvailable, replaceExt, removeExt, cleanPath, makePath, copyFile
 
-from pyworkflow.em.packages.xmipp3.convert import createClassesFromImages
-from pyworkflow.em.packages.xmipp3.utils import isMdEmpty
+from xmipp3.convert import createClassesFromImages
+from xmipp3.utils import isMdEmpty
 
 
 ctfBlockName = 'ctfGroup'

--- a/xmipp3/protocols/protocol_projmatch/protocol_projmatch.py
+++ b/xmipp3/protocols/protocol_projmatch/protocol_projmatch.py
@@ -64,7 +64,7 @@ class XmippProtProjMatch(ProtRefine3D, ProtClassify3D):
         initializeLists(self)
 
     def _loadInputInfo(self):
-        from pyworkflow.em.packages.xmipp3 import getImageLocation
+        from xmipp3.convert import getImageLocation
         
         reference = self.input3DReferences.get() # Input can be either a single volume or a set of volumes.
         
@@ -151,7 +151,7 @@ class XmippProtProjMatch(ProtRefine3D, ProtClassify3D):
         by projection matching. And copy the generated file to be
         used as initial docfile for further iterations.
         """
-        from pyworkflow.em.packages.xmipp3 import writeSetOfParticles
+        from xmipp3.convert import writeSetOfParticles
         writeSetOfParticles(self.inputParticles.get(), self.selFileName, 
                             blockName=self.blockWithAllExpImages)
         #copyFile(self.selFileName, self._getFileName('inputParticlesDoc'))
@@ -394,7 +394,7 @@ class XmippProtProjMatch(ProtRefine3D, ProtClassify3D):
                             itemDataIterator=md.iterRows(imgFn, sortByLabel=md.MDL_ITEM_ID))
     
     def _createItemMatrix(self, item, row):
-        from pyworkflow.em.packages.xmipp3.convert import createItemMatrix
+        from xmipp3.convert import createItemMatrix
         import pyworkflow.em as em
         
         createItemMatrix(item, row, align=em.ALIGN_PROJ)

--- a/xmipp3/protocols/protocol_projmatch/viewer_projmatch.py
+++ b/xmipp3/protocols/protocol_projmatch/viewer_projmatch.py
@@ -35,16 +35,16 @@ from pyworkflow.protocol.executor import StepExecutor
 from pyworkflow.viewer import CommandView, Viewer, ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import DataView, ClassesView, Classes3DView
 from pyworkflow.utils import createUniqueFileName, cleanPattern
-from protocol_projmatch import XmippProtProjMatch
+from xmipp3.protocols.protocol_projmatch import XmippProtProjMatch
 # from projmatch_initialize import createFilenameTemplates
-from pyworkflow.em.packages.xmipp3.convert import * # change this
+from xmipp3.convert import * # change this
 from pyworkflow.em.viewer import ChimeraDataView
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pyworkflow.protocol.params import (LabelParam, IntParam, FloatParam,
                                         StringParam, EnumParam, NumericRangeParam)
 import xmipp
 from pyworkflow.em.plotter import EmPlotter
-from pyworkflow.em.packages.xmipp3.plotter import XmippPlotter
+from xmipp3.viewers.plotter import XmippPlotter
 import numpy as np
 
 

--- a/xmipp3/protocols/protocol_random_conical_tilt.py
+++ b/xmipp3/protocols/protocol_random_conical_tilt.py
@@ -35,7 +35,7 @@ from pyworkflow.em.protocol import ProtInitialVolume
 from pyworkflow.em.data import Volume, SetOfParticles
 from pyworkflow.em.constants import ALIGN_2D
 
-from convert import getImageLocation, alignmentToRow
+from xmipp3.convert import getImageLocation, alignmentToRow
 from xmipp3 import XmippMdRow
 
 

--- a/xmipp3/protocols/protocol_ransac.py
+++ b/xmipp3/protocols/protocol_ransac.py
@@ -36,8 +36,8 @@ from pyworkflow.protocol.params import (PointerParam, FloatParam, BooleanParam,
 from pyworkflow.em.protocol import ProtInitialVolume
 from pyworkflow.em.data import SetOfClasses2D
 
-from convert import writeSetOfClasses2D, readSetOfVolumes, writeSetOfParticles
-from utils import isMdEmpty
+from xmipp3.convert import writeSetOfClasses2D, readSetOfVolumes, writeSetOfParticles
+from xmipp3.utils import isMdEmpty
 from pyworkflow.em.convert import ImageHandler
 
 

--- a/xmipp3/protocols/protocol_realignment_classes.py
+++ b/xmipp3/protocols/protocol_realignment_classes.py
@@ -29,9 +29,9 @@ import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 from pyworkflow.em.data import Transform
 from xmipp import MD_APPEND
-from pyworkflow.em.packages.xmipp3.convert import rowToAlignment, \
+from xmipp3.convert import rowToAlignment, \
     alignmentToRow, rowToParticle
-from convert import writeSetOfClasses2D
+from xmipp3.convert import writeSetOfClasses2D
 from pyworkflow.em import ALIGN_2D
 from pyworkflow.em.data import Class2D, Particle, Coordinate
 import numpy as np

--- a/xmipp3/protocols/protocol_reconstruct_fourier.py
+++ b/xmipp3/protocols/protocol_reconstruct_fourier.py
@@ -28,7 +28,7 @@ from pyworkflow.protocol.params import (PointerParam, FloatParam,
                                         StringParam, BooleanParam, LEVEL_ADVANCED)
 from pyworkflow.em.data import Volume
 from pyworkflow.em.protocol import ProtReconstruct3D
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 
 class XmippProtReconstructFourier(ProtReconstruct3D):
     """    

--- a/xmipp3/protocols/protocol_reconstruct_highres.py
+++ b/xmipp3/protocols/protocol_reconstruct_highres.py
@@ -40,9 +40,9 @@ from pyworkflow.em.protocol import ProtRefine3D
 from pyworkflow.em.data import SetOfVolumes, Volume
 from pyworkflow.em.metadata.utils import getFirstRow, getSize
 from pyworkflow.utils.utils import getFloatListFromValues
-from convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 from os.path import join, exists, split
-from pyworkflow.em.packages.xmipp3.convert import createItemMatrix, setXmippAttributes
+from xmipp3.convert import createItemMatrix, setXmippAttributes
 from pyworkflow.em.convert import ImageHandler
 import pyworkflow.em.metadata as md
 import pyworkflow.em as em

--- a/xmipp3/protocols/protocol_reconstruct_significant.py
+++ b/xmipp3/protocols/protocol_reconstruct_significant.py
@@ -30,9 +30,9 @@ import math
 from pyworkflow.utils import Timer
 from pyworkflow.utils.path import cleanPattern, cleanPath
 from pyworkflow.em import *
-from pyworkflow.em.packages.xmipp3.convert import volumeToRow
-from pyworkflow.em.packages.xmipp3.xmipp3 import XmippMdRow
-from convert import writeSetOfClasses2D, writeSetOfParticles
+from xmipp3.convert import volumeToRow
+from xmipp3.base import XmippMdRow
+from xmipp3.convert import writeSetOfClasses2D, writeSetOfParticles
 import pyworkflow.em.metadata as metadata
 from pyworkflow.protocol.params import *
 import xmipp

--- a/xmipp3/protocols/protocol_reconstruct_swarm.py
+++ b/xmipp3/protocols/protocol_reconstruct_swarm.py
@@ -40,9 +40,9 @@ from pyworkflow.em.protocol import ProtRefine3D
 from pyworkflow.em.data import SetOfVolumes, Volume
 from pyworkflow.em.metadata.utils import getFirstRow, getSize
 from pyworkflow.utils.utils import getFloatListFromValues
-from convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 from os.path import join, exists, split
-from pyworkflow.em.packages.xmipp3.convert import createItemMatrix, setXmippAttributes, getImageLocation
+from xmipp3.convert import createItemMatrix, setXmippAttributes, getImageLocation
 from pyworkflow.em.convert import ImageHandler
 import pyworkflow.em.metadata as md
 import pyworkflow.em as em

--- a/xmipp3/protocols/protocol_resolution3d.py
+++ b/xmipp3/protocols/protocol_resolution3d.py
@@ -28,8 +28,8 @@ from pyworkflow.em import *
 from pyworkflow.utils import *  
 from math import floor
 from xmipp3 import XmippProtocol
-from convert import createXmippInputVolumes, readSetOfVolumes, locationToXmipp
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import createXmippInputVolumes, readSetOfVolumes, locationToXmipp
+from xmipp3.convert import getImageLocation
 import pyworkflow.em.metadata as md
 from os.path import exists 
 

--- a/xmipp3/protocols/protocol_rotational_spectra.py
+++ b/xmipp3/protocols/protocol_rotational_spectra.py
@@ -33,8 +33,8 @@ from pyworkflow.gui.plotter import Plotter
 from pyworkflow.protocol.params import EnumParam, IntParam
 import xmipp, xmipp3
 
-from protocol_kerdensom import KendersomBaseClassify
-from convert import readSetOfClasses2D
+from xmipp3.protocols.protocol_kerdensom import KendersomBaseClassify
+from xmipp3.convert import readSetOfClasses2D
 
         
 class XmippProtRotSpectra(KendersomBaseClassify):

--- a/xmipp3/protocols/protocol_rotational_symmetry.py
+++ b/xmipp3/protocols/protocol_rotational_symmetry.py
@@ -28,7 +28,7 @@ import pyworkflow
 import pyworkflow.object as pwobj
 from pyworkflow.em import *  
 from xmipp import MetaData, MDL_ANGLE_ROT, MDL_ANGLE_TILT
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 
 

--- a/xmipp3/protocols/protocol_screen_particles.py
+++ b/xmipp3/protocols/protocol_screen_particles.py
@@ -38,7 +38,7 @@ from pyworkflow.object import String, Set, Float
 from pyworkflow.protocol.params import (EnumParam, IntParam, Positive,
                                         Range, LEVEL_ADVANCED, FloatParam,
                                         BooleanParam)
-from convert import readSetOfParticles, writeSetOfParticles, setXmippAttributes
+from xmipp3.convert import readSetOfParticles, writeSetOfParticles, setXmippAttributes
 
 
 class XmippProtScreenParticles(ProtProcessParticles):

--- a/xmipp3/protocols/protocol_solid_angles.py
+++ b/xmipp3/protocols/protocol_solid_angles.py
@@ -33,14 +33,14 @@ from pyworkflow.utils.path import makePath
 from pyworkflow.em.convert import ImageHandler, ALIGN_PROJ
 from pyworkflow.em.data import Image
 from pyworkflow.em.protocol import ProtAnalysis3D
-from pyworkflow.em.packages.xmipp3.convert import createItemMatrix, writeSetOfParticles
+from xmipp3.convert import createItemMatrix, writeSetOfParticles
 import pyworkflow.em.metadata as md
 import pyworkflow.em as em
 
 import xmipp
-from convert import rowToAlignment, setXmippAttributes, xmippToLocation
+from xmipp3.convert import rowToAlignment, setXmippAttributes, xmippToLocation
 from xmipp3 import findRow
-from constants import SYM_URL
+from xmipp3.constants import SYM_URL
 
 
 class XmippProtSolidAngles(ProtAnalysis3D):

--- a/xmipp3/protocols/protocol_split_volume.py
+++ b/xmipp3/protocols/protocol_split_volume.py
@@ -32,7 +32,7 @@ from pyworkflow.protocol.params import PointerParam, FloatParam, IntParam, Strin
 from pyworkflow.em.protocol import ProtClassify3D
 from pyworkflow.em.data import Volume
 from pyworkflow.em.convert import ImageHandler
-from convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 
 class XmippProtSplitvolume(ProtClassify3D):
     """Split volume in two"""

--- a/xmipp3/protocols/protocol_subtract_projection.py
+++ b/xmipp3/protocols/protocol_subtract_projection.py
@@ -30,7 +30,7 @@ from pyworkflow.protocol.params import PointerParam, EnumParam, BooleanParam
 
 from pyworkflow.em.protocol import ProtOperateParticles
 from pyworkflow.protocol.constants import STEPS_PARALLEL
-from pyworkflow.em.packages.xmipp3.convert import (XmippMdRow, particleToRow,
+from xmipp3.convert import (XmippMdRow, particleToRow,
                                                    getImageLocation,
                                                    geometryFromMatrix)
 import xmipp

--- a/xmipp3/protocols/protocol_validate_nontilt.py
+++ b/xmipp3/protocols/protocol_validate_nontilt.py
@@ -31,7 +31,7 @@ from pyworkflow.protocol.params import (PointerParam, FloatParam, STEPS_PARALLEL
 from pyworkflow.em.data import Volume
 from pyworkflow.em.protocol import ProtAnalysis3D
 from pyworkflow.utils.path import moveFile, makePath
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 import pyworkflow.em.metadata as md
 
 

--- a/xmipp3/protocols/protocol_validate_overfitting.py
+++ b/xmipp3/protocols/protocol_validate_overfitting.py
@@ -31,7 +31,7 @@ from pyworkflow.protocol.params import (PointerParam, FloatParam,
                                         LEVEL_ADVANCED)
 from pyworkflow.em.data import Volume
 from pyworkflow.em.protocol import ProtReconstruct3D
-from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 from pyworkflow.utils import getFloatListFromValues
 from pyworkflow.utils.path import cleanPattern, cleanPath, copyFile
 import xmipp

--- a/xmipp3/protocols/protocol_volume_homogenizer.py
+++ b/xmipp3/protocols/protocol_volume_homogenizer.py
@@ -29,7 +29,7 @@
 import pyworkflow.protocol.params as params
 from pyworkflow import VERSION_1_1
 from pyworkflow.em.protocol import ProtProcessParticles
-from pyworkflow.em.packages.xmipp3.convert import (writeSetOfParticles, 
+from xmipp3.convert import (writeSetOfParticles,
                                                    readSetOfParticles,
                                                    geometryFromMatrix,
                                                    SetOfParticles)

--- a/xmipp3/protocols/protocol_volume_strain.py
+++ b/xmipp3/protocols/protocol_volume_strain.py
@@ -32,7 +32,7 @@ from pyworkflow.protocol.params import PointerParam, StringParam, FloatParam
 from pyworkflow.em.protocol.protocol import EMProtocol
 from pyworkflow.em.protocol.protocol_3d import ProtAnalysis3D
 from pyworkflow.utils import cleanPath
-from xmipp3 import getMatlabEnviron
+from xmipp3 import Plugin
 # import xmipp
 
         

--- a/xmipp3/tests/test_convert_xmipp.py
+++ b/xmipp3/tests/test_convert_xmipp.py
@@ -26,14 +26,17 @@
 # *
 # **************************************************************************
 
-import os
-from pyworkflow.em.data import SetOfVolumes
-import unittest
 
-import xmipp
-from pyworkflow.em.packages.xmipp3 import *
+from pyworkflow.em.data import SetOfVolumes
+
+
+# import xmipp
+# from xmipp3 import *
+from xmipp3.base import *
+from xmipp3.convert import *
+from xmipp.constants import *
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3.convert import *
+
 import subprocess
 from pyworkflow.utils.properties import colorText
 

--- a/xmipp3/tests/test_protocol_apply_transformation_matrix.py
+++ b/xmipp3/tests/test_protocol_apply_transformation_matrix.py
@@ -23,8 +23,8 @@
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em.protocol import ProtImportParticles, ProtImportVolumes
-from pyworkflow.em.packages.xmipp3.protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
-from pyworkflow.em.packages.xmipp3.protocol_align_volume import XmippProtAlignVolume, ALIGN_ALGORITHM_LOCAL
+from xmipp3.protocol.protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
+from xmipp3.protocol.protocol_align_volume import XmippProtAlignVolume, ALIGN_ALGORITHM_LOCAL
     
 class TestApplyTransformationMatrix(BaseTest):
     @classmethod

--- a/xmipp3/tests/test_protocol_combine_pdb.py
+++ b/xmipp3/tests/test_protocol_combine_pdb.py
@@ -27,7 +27,7 @@
 
 from pyworkflow.tests import *
 from pyworkflow.em.protocol.protocol_import import ProtImportPdb
-from pyworkflow.em.packages.xmipp3.pdb.protocol_combine_pdb import XmippProtCombinePdb
+from xmipp3.protocols.pdb.protocol_combine_pdb import XmippProtCombinePdb
 
 class TestCombinePdb(BaseTest):     
     @classmethod

--- a/xmipp3/tests/test_protocol_compare_angles.py
+++ b/xmipp3/tests/test_protocol_compare_angles.py
@@ -24,7 +24,7 @@
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em.protocol import ProtImportParticles, ProtSplitSet
-from pyworkflow.em.packages.xmipp3 import XmippProtCompareAngles
+from xmipp3.protocols import XmippProtCompareAngles
 
 
 class TestXmippProtCompareAngles(BaseTest):

--- a/xmipp3/tests/test_protocol_consensus_classes3D.py
+++ b/xmipp3/tests/test_protocol_consensus_classes3D.py
@@ -34,7 +34,7 @@ from pyworkflow.utils import redStr, greenStr, magentaStr
 from pyworkflow.em.data import Class3D
 
 from pyworkflow.em.protocol.protocol_import import ProtImportParticles
-from pyworkflow.em.packages.xmipp3.protocol_consensus_classes3D import \
+from xmipp3.protocol.protocol_consensus_classes3D import \
                                                      XmippProtConsensusClasses3D
 
 class TestConsensusClasses3D(BaseTest):

--- a/xmipp3/tests/test_protocol_extract_unit_cell.py
+++ b/xmipp3/tests/test_protocol_extract_unit_cell.py
@@ -37,13 +37,13 @@ from pyworkflow.em.constants import SYM_I222r, SYM_I222, SCIPION_SYM_NAME, \
 from pyworkflow.em.convert import ImageHandler
 from pyworkflow.em.data import Transform
 from pyworkflow.em.headers import Ccp4Header
-from pyworkflow.em.packages.xmipp3 import getEnviron
-from pyworkflow.em.packages.xmipp3.constants import XMIPP_SYM_NAME
-from pyworkflow.em.packages.xmipp3.pdb.protocol_pseudoatoms \
+from xmipp3 import Plugin
+from xmipp3.constants import XMIPP_SYM_NAME
+from xmipp3.protocols.pdb.protocol_pseudoatoms \
     import XmippProtConvertToPseudoAtoms
-from pyworkflow.em.packages.xmipp3.pdb.protocol_pseudoatoms_base \
+from xmipp3.protocols.pdb.protocol_pseudoatoms_base \
     import NMA_MASK_THRE
-from pyworkflow.em.packages.xmipp3.protocol_extract_unit_cell \
+from xmipp3.protocol.protocol_extract_unit_cell \
     import XmippProtExtractUnit
 from pyworkflow.em.protocol import ProtImportVolumes
 from pyworkflow.em.symmetry import Icosahedron
@@ -470,7 +470,7 @@ class TestProtModelBuilding(BaseTest):
         command = "xmipp_phantom_create "
         args = " -i %s" % self.filename[sym]
         args += " -o %s" % outputFile1
-        runJob(None, command, args, env=getEnviron())
+        runJob(None, command, args, env=Plugin.getEnviron())
         ccp4header = Ccp4Header(outputFile1, readHeader=True)
         x, y, z = ccp4header.getDims()
         t = Transform()
@@ -485,7 +485,7 @@ class TestProtModelBuilding(BaseTest):
             args += " %d " % (+ x / 2.)
             args += " %d " % (+ y / 2.)
             args += " %d " % (+ z / 2.)
-            runJob(None, "xmipp_transform_window", args, env=getEnviron())
+            runJob(None, "xmipp_transform_window", args, env=Plugin.getEnviron())
             t.setShifts(0, 0, 0)
             outputFile = outputFile2
             ccp4header = Ccp4Header(outputFile2, readHeader=True)

--- a/xmipp3/tests/test_protocol_multiple_fsc.py
+++ b/xmipp3/tests/test_protocol_multiple_fsc.py
@@ -30,7 +30,7 @@ import unittest, sys
 from pyworkflow.em import *
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 from pyworkflow.em.protocol import ProtImportVolumes, ProtImportMask
-from pyworkflow.em.packages.xmipp3 import XmippProtMultipleFSCs
+from xmipp3.protocols import XmippProtMultipleFSCs
 
 
 

--- a/xmipp3/tests/test_protocol_multireference_alignability.py
+++ b/xmipp3/tests/test_protocol_multireference_alignability.py
@@ -27,7 +27,7 @@
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em.protocol import ProtImportParticles, ProtImportVolumes, ProtSubSet
-from pyworkflow.em.packages.xmipp3 import XmippProtMultiRefAlignability
+from xmipp3.protocol import XmippProtMultiRefAlignability
 
 
 class TestMultireferenceAlignability(BaseTest):

--- a/xmipp3/tests/test_protocol_structure_mapping.py
+++ b/xmipp3/tests/test_protocol_structure_mapping.py
@@ -23,7 +23,7 @@
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em.protocol import ProtImportVolumes
-from pyworkflow.em.packages.xmipp3.nma.protocol_structure_mapping import XmippProtStructureMapping
+from xmipp3.protocols.nma.protocol_structure_mapping import XmippProtStructureMapping
 
     
 class TestStructureMapping(BaseTest):

--- a/xmipp3/tests/test_protocol_validate_overfitting.py
+++ b/xmipp3/tests/test_protocol_validate_overfitting.py
@@ -23,7 +23,7 @@
 
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em.protocol import ProtImportParticles, ProtImportVolumes
-from pyworkflow.em.packages.xmipp3.protocol_validate_overfitting import XmippProtValidateOverfitting
+from xmipp3.protocols.protocol_validate_overfitting import XmippProtValidateOverfitting
        
     
 class TestValidateOverfitting(BaseTest):

--- a/xmipp3/tests/test_protocols_add_noise.py
+++ b/xmipp3/tests/test_protocols_add_noise.py
@@ -28,7 +28,7 @@ import unittest, sys
 
 from pyworkflow.em import exists
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
-from pyworkflow.em.packages.xmipp3 import XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles
+from xmipp3.protocol import XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles
 from pyworkflow.em.protocol import ProtImportVolumes, ProtImportParticles
 
 

--- a/xmipp3/tests/test_protocols_gpuCorr_classifier.py
+++ b/xmipp3/tests/test_protocols_gpuCorr_classifier.py
@@ -26,8 +26,8 @@ from pyworkflow.em.protocol import ProtImportAverages, ProtImportMicrographs
 from pyworkflow.em.protocol.protocol_sets import ProtSubSet
 from pyworkflow.em.packages.grigoriefflab import ProtCTFFind
 from pyworkflow.em.packages.eman2.protocol_autopick import *
-from pyworkflow.em.packages.xmipp3.protocol_extract_particles import *
-from pyworkflow.em.packages.xmipp3.protocol_classification_gpuCorr import *
+from xmipp3.protocol.protocol_extract_particles import *
+from xmipp3.protocol.protocol_classification_gpuCorr import *
 
 
 # Number of mics to be processed

--- a/xmipp3/tests/test_protocols_gpuCorr_fullStreaming.py
+++ b/xmipp3/tests/test_protocols_gpuCorr_fullStreaming.py
@@ -28,8 +28,8 @@ from pyworkflow.em.protocol.protocol_create_stream_data import \
 from pyworkflow.protocol import getProtocolFromDb
 from pyworkflow.em.packages.grigoriefflab import ProtCTFFind
 from pyworkflow.em.packages.eman2.protocol_autopick import *
-from pyworkflow.em.packages.xmipp3.protocol_extract_particles import *
-from pyworkflow.em.packages.xmipp3.protocol_classification_gpuCorr_full \
+from xmipp3.protocol.protocol_extract_particles import *
+from xmipp3.protocol.protocol_classification_gpuCorr_full \
     import *
 import time
 

--- a/xmipp3/tests/test_protocols_gpuCorr_semiStreaming.py
+++ b/xmipp3/tests/test_protocols_gpuCorr_semiStreaming.py
@@ -28,10 +28,13 @@ from pyworkflow.em.protocol.protocol_create_stream_data import \
     SET_OF_MICROGRAPHS
 from pyworkflow.protocol import getProtocolFromDb
 from pyworkflow.em.packages.grigoriefflab import ProtCTFFind
-from pyworkflow.em.packages.eman2.protocol_autopick import *
-from pyworkflow.em.packages.xmipp3.protocol_extract_particles import *
-from pyworkflow.em.packages.xmipp3.protocol_classification_gpuCorr_semi \
-    import *
+try:
+    from eman2.protocol_autopick import *
+except:
+    print("Eman is needed to do this test")
+
+from xmipp3.protocols.protocol_extract_particles import *
+from xmipp3.protocol_classification_gpuCorr_semi import *
 import time
 
 

--- a/xmipp3/tests/test_protocols_highres.py
+++ b/xmipp3/tests/test_protocols_highres.py
@@ -28,7 +28,7 @@ import unittest, sys
 
 from pyworkflow.em import exists
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
-from pyworkflow.em.packages.xmipp3 import XmippProtReconstructHighRes
+from xmipp3.protocol import XmippProtReconstructHighRes
 from pyworkflow.em.protocol import ProtImportVolumes, ProtImportParticles
 from pyworkflow.em.protocol.protocol_sets import ProtSubSet
 import xmipp

--- a/xmipp3/tests/test_protocols_mixed_movies.py
+++ b/xmipp3/tests/test_protocols_mixed_movies.py
@@ -28,7 +28,7 @@ from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.protocol import ProtImportMovies
 
-from pyworkflow.em.packages.xmipp3 import (XmippProtMovieCorr,
+from xmipp3.protocol import (XmippProtMovieCorr,
                                            XmippProtOFAlignment,
                                            XmippProtMovieAverage)
 

--- a/xmipp3/tests/test_protocols_mltomo.py
+++ b/xmipp3/tests/test_protocols_mltomo.py
@@ -25,7 +25,7 @@
 # **************************************************************************
 
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3 import ProtImportVolumes, XmippProtMLTomo
+from xmipp3.protocol import ProtImportVolumes, XmippProtMLTomo
 
 
 class TestMLTomoBase(BaseTest):

--- a/xmipp3/tests/test_protocols_monores.py
+++ b/xmipp3/tests/test_protocols_monores.py
@@ -27,9 +27,9 @@
 import unittest, sys
 # import numpy as np
 from pyworkflow.em import exists
-#from pyworkflow.em.packages.xmipp3.protocol_resolution_monogenic_signal import OUTPUT_RESOLUTION_FILE
+#from xmipp3.protocol.protocol_resolution_monogenic_signal import OUTPUT_RESOLUTION_FILE
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
-from pyworkflow.em.packages.xmipp3 import XmippProtMonoRes, XmippProtCreateMask3D
+from xmipp3.protocol import XmippProtMonoRes, XmippProtCreateMask3D
 from pyworkflow.em.protocol import ProtImportVolumes
 
 

--- a/xmipp3/tests/test_protocols_realignment_classes.py
+++ b/xmipp3/tests/test_protocols_realignment_classes.py
@@ -26,9 +26,9 @@ from pyworkflow.em.protocol import ProtImportMicrographs
 from pyworkflow.em.protocol.protocol_sets import ProtSubSet
 from pyworkflow.em.packages.grigoriefflab import ProtCTFFind
 from pyworkflow.em.packages.eman2.protocol_autopick import *
-from pyworkflow.em.packages.xmipp3.protocol_extract_particles import *
-from pyworkflow.em.packages.xmipp3.protocol_cl2d import *
-from pyworkflow.em.packages.xmipp3.protocol_realignment_classes import *
+from xmipp3.protocol.protocol_extract_particles import *
+from xmipp3.protocol.protocol_cl2d import *
+from xmipp3.protocol.protocol_realignment_classes import *
 
 
 # Number of mics to be processed

--- a/xmipp3/tests/test_protocols_solid_angles.py
+++ b/xmipp3/tests/test_protocols_solid_angles.py
@@ -29,7 +29,7 @@ from pyworkflow.em.protocol import (ProtImportParticles, ProtImportVolumes,
 from pyworkflow.em import ProtUserSubSet
 
 
-from pyworkflow.em.packages.xmipp3 import XmippProtSolidAngles, XmippProtSplitvolume
+from xmipp3.protocols import XmippProtSolidAngles, XmippProtSplitvolume
 
 
 class TestDirectionalClasses(BaseTest):

--- a/xmipp3/tests/test_protocols_subtract_projection.py
+++ b/xmipp3/tests/test_protocols_subtract_projection.py
@@ -23,16 +23,16 @@ import os
 
 from pyworkflow.tests import BaseTest, setupTestProject
 import xmipp
-from pyworkflow.em.packages.xmipp3 import writeSetOfParticles
+from xmipp3.convert import writeSetOfParticles
 from pyworkflow.em.data import SetOfParticles
 from pyworkflow.em.constants import ALIGN_PROJ
 import numpy as np
 from pyworkflow.em.data import Acquisition, Particle, Transform
 import random
 from pyworkflow.em.data import CTFModel
-from pyworkflow.em.packages.xmipp3 import getEnviron, runXmippProgram
+from xmipp3 import Plugin
 from pyworkflow.em.protocol import ProtImportParticles, ProtImportMask, ProtImportVolumes
-from pyworkflow.em.packages.xmipp3 import XmippProtSubtractProjection
+from xmipp3.protocol import XmippProtSubtractProjection
 from pyworkflow.em.data import  VolumeMask
 from pyworkflow.em.packages.relion import ProtRelionSubtract
 proj1 = [(0, 0, 53, 55, 0.5), (0, 0, 53, 56, 1.0), (0, 0, 53, 57, 0.5), (0, 0, 53, 63, 0.5), (0, 0, 53, 64, 1.0),
@@ -461,13 +461,13 @@ class TestSubProj(BaseTest):
         args += " -o %s"%self.proj.getTmpPath(setPartCtfName)
         args += " -f ctf %s"%baseFnCtf
         args += " --sampling %f"%samplingRate
-        runXmippProgram("xmipp_transform_filter", args)
+        Plugin.runXmippProgram("xmipp_transform_filter", args)
 
         args  = " -i %s"%setPartMd
         args += " -o %s"%self.proj.getTmpPath(setPartCtfPosName)
         args += " -f ctfpos %s"%baseFnCtf
         args += " --sampling %f"%samplingRate
-        runXmippProgram("xmipp_transform_filter", args)
+        Plugin.runXmippProgram("xmipp_transform_filter", args)
 
     def importData(self, baseFn, objLabel, protType, importFrom):
         prot = self.newProtocol(protType,

--- a/xmipp3/tests/test_protocols_xmipp_2d.py
+++ b/xmipp3/tests/test_protocols_xmipp_2d.py
@@ -31,11 +31,14 @@ from __future__ import print_function
 from pyworkflow.tests.test_utils import wait
 from pyworkflow.utils import magentaStr
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3 import *
-from pyworkflow.em.packages.xmipp3 import XmippFilterHelper as xfh
-from pyworkflow.em.packages.xmipp3 import XmippResizeHelper as xrh
-from pyworkflow.em.packages.xmipp3.protocol_preprocess import (
-    OP_DOTPRODUCT, OP_MULTIPLY, OP_SQRT)
+from pyworklow.em.protocol.protocol_import import *
+
+from xmipp3.base import *
+from xmipp3.convert import *
+from xmipp3.constants import *
+from xmipp3.protocols.protocol_preprocess import XmippFilterHelper as xfh
+from xmipp3.protocols.protocol_preprocess import XmippResizeHelper as xrh
+from xmipp3.protocols.protocol_preprocess import OP_DOTPRODUCT, OP_MULTIPLY, OP_SQRT
 
 
 # Some utility functions to import particles that are used

--- a/xmipp3/tests/test_protocols_xmipp_3d.py
+++ b/xmipp3/tests/test_protocols_xmipp_3d.py
@@ -32,13 +32,15 @@ from itertools import izip
 from pyworkflow.utils import redStr, greenStr, magentaStr
 from pyworkflow.tests import *
 from pyworkflow.em import *
-from pyworkflow.em.packages.xmipp3 import *
-from pyworkflow.em.packages.xmipp3 import (XmippFilterHelper as xfh,
-                                           XmippResizeHelper as xrh)
-from pyworkflow.em.packages.xmipp3.protocol_align_volume import (
+from xmipp3.base import *
+from xmipp3.convert import *
+from xmipp3.constants import *
+from xmipp3.protocols import (XmippFilterHelper as xfh,
+                              XmippResizeHelper as xrh)
+from xmipp3.protocols.protocol_align_volume import (
     ALIGN_ALGORITHM_EXHAUSTIVE, ALIGN_ALGORITHM_EXHAUSTIVE_LOCAL,
     ALIGN_ALGORITHM_LOCAL)
-from pyworkflow.em.packages.xmipp3.protocol_preprocess import (
+from xmipp3.protocols.protocol_preprocess import (
     OP_COLUNM, OP_DOTPRODUCT, OP_MULTIPLY, OP_SQRT, OP_RADIAL, OP_ROW)
 
 class TestXmippBase(BaseTest):

--- a/xmipp3/tests/test_protocols_xmipp_mics.py
+++ b/xmipp3/tests/test_protocols_xmipp_mics.py
@@ -30,7 +30,9 @@ from os.path import join, basename
 
 from pyworkflow.em import *
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3 import *
+from xmipp3.base import *
+from xmipp3.convert import *
+from xmipp3.constants import *
 from pyworkflow.protocol import getProtocolFromDb
 import pyworkflow.utils as pwutils
 

--- a/xmipp3/tests/test_protocols_xmipp_movie_resize.py
+++ b/xmipp3/tests/test_protocols_xmipp_movie_resize.py
@@ -27,10 +27,9 @@
 
 
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3 import ProtImportMovies
+from pyworkflow.em.protocol.import_protocol import ProtImportMovies
 from pyworkflow.protocol import getProtocolFromDb
-from pyworkflow.em.packages.xmipp3.protocol_preprocess import \
-    XmippProtMovieResize
+from xmipp3.protocols.protocol_preprocess import XmippProtMovieResize
 from pyworkflow.em.protocol import ProtCreateStreamData
 from pyworkflow.em.protocol.protocol_create_stream_data import \
     SET_OF_MOVIES

--- a/xmipp3/tests/test_protocols_xmipp_movies.py
+++ b/xmipp3/tests/test_protocols_xmipp_movies.py
@@ -25,10 +25,12 @@
 # *
 # **************************************************************************
 
-from os.path import basename, abspath
+from os.path import abspath
 
 from pyworkflow.tests import *
-from pyworkflow.em.packages.xmipp3 import *
+from xmipp3.base import *
+from xmipp3.convert import *
+from xmipp3.constants import *
 
 
 # Some utility functions to import movies that are used in several tests.

--- a/xmipp3/viewers/__init__.py
+++ b/xmipp3/viewers/__init__.py
@@ -27,22 +27,22 @@
 from viewer import XmippViewer
 from plotter import XmippPlotter
 
-# from viewer_cl2d import XmippCL2DViewer
-# from viewer_cltomo import XmippCLTomoViewer
-# from viewer_ctf_discrepancy import XmippCTFDiscrepancyViewer
-# from viewer_ml2d import XmippML2DViewer
-# from viewer_mltomo import XmippMLTomoViewer
-# from viewer_movie_alignment import XmippMovieAlignViewer
-# from viewer_normalize_strain import XmippNormalizeStrainViewer
-# from viewer_resolution3d import XmippResolution3DViewer
-# from viewer_resolution_monogenic_signal import XmippMonoResViewer
-# from viewer_validate_nontilt import XmippValidateNonTiltViewer
-# from viewer_split_volume import XmippViewerSplitVolume
-# from viewer_validate_overfitting import XmippValidateOverfittingViewer
-# from viewer_volume_strain import XmippVolumeStrainViewer
-# from viewer_reconstruct_highres import XmippReconstructHighResViewer
-# from viewer_solid_angles import SolidAnglesViewer
-# from viewer_extract_unit_cell import viewerXmippProtExtractUnit
+from viewer_cl2d import XmippCL2DViewer
+from viewer_cltomo import XmippCLTomoViewer
+from viewer_ctf_discrepancy import XmippCTFDiscrepancyViewer
+from viewer_ml2d import XmippML2DViewer
+from viewer_mltomo import XmippMLTomoViewer
+from viewer_movie_alignment import XmippMovieAlignViewer
+from viewer_normalize_strain import XmippNormalizeStrainViewer
+from viewer_resolution3d import XmippResolution3DViewer
+from viewer_resolution_monogenic_signal import XmippMonoResViewer
+from viewer_validate_nontilt import XmippValidateNonTiltViewer
+from viewer_split_volume import XmippViewerSplitVolume
+from viewer_validate_overfitting import XmippValidateOverfittingViewer
+from viewer_volume_strain import XmippVolumeStrainViewer
+from viewer_reconstruct_highres import XmippReconstructHighResViewer
+from viewer_solid_angles import SolidAnglesViewer
+from viewer_extract_unit_cell import viewerXmippProtExtractUnit
 
 
 

--- a/xmipp3/viewers/viewer.py
+++ b/xmipp3/viewers/viewer.py
@@ -41,28 +41,28 @@ import xmipp
 import xmipp3
 from xmipp3.convert import *
 
-# from protocol_cl2d_align import XmippProtCL2DAlign
-# from protocol_cl2d import XmippProtCL2D
-# from protocol_compare_reprojections import XmippProtCompareReprojections
-# from protocol_compare_angles import XmippProtCompareAngles
-# from protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
-# from protocol_extract_particles import XmippProtExtractParticles
-# from protocol_extract_particles_pairs import XmippProtExtractParticlesPairs
-# from protocol_helical_parameters import XmippProtHelicalParameters
-# from protocol_kerdensom import XmippProtKerdensom
-# from protocol_particle_pick_automatic import XmippParticlePickingAutomatic
-# from protocol_particle_pick import XmippProtParticlePicking
-# from protocol_particle_pick_pairs import XmippProtParticlePickingPairs
-# from protocol_preprocess import XmippProtPreprocessVolumes
-# from protocol_preprocess_micrographs import XmippProtPreprocessMicrographs
-# from protocol_rotational_spectra import XmippProtRotSpectra
-# from protocol_screen_particles import XmippProtScreenParticles
-# from protocol_ctf_micrographs import XmippProtCTFMicrographs
-#
-# from protocol_validate_nontilt import XmippProtValidateNonTilt
-# from protocol_multireference_alignability import XmippProtMultiRefAlignability
-# from protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
-# from protocol_movie_gain import XmippProtMovieGain
+from xmipp3.protocols.protocol_cl2d_align import XmippProtCL2DAlign
+from xmipp3.protocols.protocol_cl2d import XmippProtCL2D
+from xmipp3.protocols.protocol_compare_reprojections import XmippProtCompareReprojections
+from xmipp3.protocols.protocol_compare_angles import XmippProtCompareAngles
+from xmipp3.protocols.protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
+from xmipp3.protocols.protocol_extract_particles import XmippProtExtractParticles
+from xmipp3.protocols.protocol_extract_particles_pairs import XmippProtExtractParticlesPairs
+from xmipp3.protocols.protocol_helical_parameters import XmippProtHelicalParameters
+from xmipp3.protocols.protocol_kerdensom import XmippProtKerdensom
+from xmipp3.protocols.protocol_particle_pick_automatic import XmippParticlePickingAutomatic
+from xmipp3.protocols.protocol_particle_pick import XmippProtParticlePicking
+from xmipp3.protocols.protocol_particle_pick_pairs import XmippProtParticlePickingPairs
+from xmipp3.protocols.protocol_preprocess import XmippProtPreprocessVolumes
+from xmipp3.protocols.protocol_preprocess_micrographs import XmippProtPreprocessMicrographs
+from xmipp3.protocols.protocol_rotational_spectra import XmippProtRotSpectra
+from xmipp3.protocols.protocol_screen_particles import XmippProtScreenParticles
+from xmipp3.protocols.protocol_ctf_micrographs import XmippProtCTFMicrographs
+
+from xmipp3.protocols.protocol_validate_nontilt import XmippProtValidateNonTilt
+from xmipp3.protocols.protocol_multireference_alignability import XmippProtMultiRefAlignability
+from xmipp3.protocols.protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
+from xmipp3.protocols.protocol_movie_gain import XmippProtMovieGain
 
 
 class XmippViewer(Viewer):
@@ -82,22 +82,22 @@ class XmippViewer(Viewer):
                 SetOfImages,
                 SetOfMovies,
                 SetOfNormalModes,
-                SetOfPDBs #,
-                # XmippProtCompareReprojections,
-                # XmippProtCompareAngles,
-                # XmippParticlePickingAutomatic,
-                # XmippProtExtractParticles,
-                # XmippProtExtractParticlesPairs,
-                # XmippProtKerdensom,
-                # ProtParticlePicking,
-                # XmippProtParticlePickingPairs,
-                # XmippProtRotSpectra,
-                # XmippProtScreenParticles,
-                # XmippProtCTFMicrographs,
-                # XmippProtValidateNonTilt,
-                # XmippProtAssignmentTiltPair,
-                # XmippProtMultiRefAlignability,
-                # XmippProtMovieGain
+                SetOfPDBs ,
+                XmippProtCompareReprojections,
+                XmippProtCompareAngles,
+                XmippParticlePickingAutomatic,
+                XmippProtExtractParticles,
+                XmippProtExtractParticlesPairs,
+                XmippProtKerdensom,
+                ProtParticlePicking,
+                XmippProtParticlePickingPairs,
+                XmippProtRotSpectra,
+                XmippProtScreenParticles,
+                XmippProtCTFMicrographs,
+                XmippProtValidateNonTilt,
+                XmippProtAssignmentTiltPair,
+                XmippProtMultiRefAlignability,
+                XmippProtMovieGain
                 ]
 
     def __init__(self, **kwargs):
@@ -252,18 +252,17 @@ class XmippViewer(Viewer):
             self._views.append(
                 ObjectView(self._project, obj.strId(), fn, **kwargs))
 
-        #  FIXME
-        # if issubclass(cls, XmippProtCTFMicrographs):
-        #     if obj.hasAttribute('outputCTF'):
-        #         ctfSet = obj.outputCTF
-        #     else:
-        #         mics = obj.inputMicrographs.get()
-        #         ctfSet = self.__createTemporaryCtfs(obj, mics)
-        #
-        #     if ctfSet.isEmpty():
-        #         self._views.append(self.infoMessage("No CTF estimation has finished yet"))
-        #     else:
-        #         self._views.append(CtfView(self._project, ctfSet))
+        if issubclass(cls, XmippProtCTFMicrographs):
+            if obj.hasAttribute('outputCTF'):
+                ctfSet = obj.outputCTF
+            else:
+                mics = obj.inputMicrographs.get()
+                ctfSet = self.__createTemporaryCtfs(obj, mics)
+
+            if ctfSet.isEmpty():
+                self._views.append(self.infoMessage("No CTF estimation has finished yet"))
+            else:
+                self._views.append(CtfView(self._project, ctfSet))
 
         elif issubclass(cls, SetOfCTF):
             self._views.append(CtfView(self._project, obj))
@@ -286,141 +285,140 @@ class XmippViewer(Viewer):
             writeSetOfCoordinates(tmpDir, obj.getTilted())
             launchTiltPairPickerGUI(mdFn, tmpDir, self.protocol)
 
-        # FIXME
-        # elif (issubclass(cls, XmippProtExtractParticles) or
-        #       issubclass(cls, XmippProtScreenParticles)):
-        #     particles = obj.outputParticles
-        #     self._visualize(particles)
-        #
-        #     fn = obj._getPath('images.xmd')
-        #     if os.path.exists(fn): # it doesnt unless cls is Xmipp
-        #         md = xmipp.MetaData(fn)
-        #         # If Zscore on output images plot Zscore particle sorting
-        #         if md.containsLabel(xmipp.MDL_ZSCORE):
-        #             from plotter import XmippPlotter
-        #             xplotter = XmippPlotter(windowTitle="Zscore particles sorting")
-        #             xplotter.createSubPlot("Particle sorting", "Particle number", "Zscore")
-        #             xplotter.plotMd(md, False, mdLabelY=xmipp.MDL_ZSCORE)
-        #             self._views.append(xplotter)
-        #         # If VARscore on output images plot VARscore particle sorting
-        #         if md.containsLabel(xmipp.MDL_SCORE_BY_VAR):
-        #             from plotter import XmippPlotter
-        #             xplotter = XmippPlotter(windowTitle="Variance particles sorting")
-        #             xplotter.createSubPlot("Variance Histogram", "Variance", "Number of particles")
-        #             xplotter.plotMd(md, False, mdLabelY=xmipp.MDL_SCORE_BY_VAR, nbins=100)
-        #             self._views.append(xplotter)
-        #
-        # elif issubclass(cls, XmippProtMovieGain):
-        #     self._visualize(obj.outputMovies)
-        #     movieGainMonitor = MonitorMovieGain(obj,
-        #                                         workingDir=obj.workingDir.get(),
-        #                                         samplingInterval=60,
-        #                                         monitorTime=300,
-        #                                         stddevValue=0.04,
-        #                                         ratio1Value=1.15,
-        #                                         ratio2Value=4.5)
-        #     self._views.append(MovieGainMonitorPlotter(movieGainMonitor))
-        #
-        # elif issubclass(cls, XmippProtRotSpectra):
-        #     self._visualize(obj.outputClasses,
-        #                     viewParams={'columns': obj.SomXdim.get(),
-        #                                 RENDER: ' spectraPlot._filename average._filename',
-        #                                 ZOOM: 30,
-        #                                 VISIBLE:  'enabled id _size average._filename spectraPlot._filename',
-        #                                 'labels': 'id _size',
-        #                                 SORT_BY: 'id'})
-        #
-        # elif issubclass(cls, XmippProtKerdensom):
-        #     self._visualize(obj.outputClasses,
-        #                     viewParams={'columns': obj.SomXdim.get(),
-        #                                'render': 'average._filename _representative._filename',
-        #                                'labels': '_size',
-        #                                'sortby': 'id'})
-        #
-        #
-        #
-        # elif issubclass(cls, XmippProtCompareReprojections):
-        #         fn = obj.outputParticles.getFileName()
-        #         labels = 'id enabled _index _xmipp_image._filename _xmipp_imageRef._filename _xmipp_imageResidual._filename _xmipp_imageCovariance._filename _xmipp_cost _xmipp_zScoreResCov _xmipp_zScoreResMean _xmipp_zScoreResVar _xmipp_continuousA _xmipp_continuousB _xmipp_continuousX _xmipp_continuousY'
-        #         labelRender = "_xmipp_image._filename _xmipp_imageRef._filename _xmipp_imageResidual._filename _xmipp_imageCovariance._filename"
-        #         self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
-        #                                       viewParams={ORDER: labels,
-        #                                               VISIBLE: labels,
-        #                                               SORT_BY: '_xmipp_cost asc', RENDER:labelRender,
-        #                                               MODE: MODE_MD}))
-        #
-        # elif issubclass(cls, XmippProtCompareAngles):
-        #         fn = obj.outputParticles.getFileName()
-        #         labels = 'id enabled _index _filename _xmipp_shiftDiff _xmipp_angleDiff'
-        #         labelRender = "_filename"
-        #         self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
-        #                                       viewParams={ORDER: labels,
-        #                                               VISIBLE: labels,
-        #                                               SORT_BY: '_xmipp_angleDiff asc', RENDER:labelRender,
-        #                                               MODE: MODE_MD}))
-        #
-        # elif issubclass(cls, XmippParticlePickingAutomatic):
-        #     micSet = obj.getInputMicrographs()
-        #     mdFn = getattr(micSet, '_xmippMd', None)
-        #     inTmpFolder = False
-        #     if mdFn:
-        #         micsfn = mdFn.get()
-        #     else:  # happens if protocol is not an xmipp one
-        #         micsfn = self._getTmpPath(micSet.getName() + '_micrographs.xmd')
-        #         writeSetOfMicrographs(micSet, micsfn)
-        #         inTmpFolder = True
-        #
-        #     posDir = obj._getExtraPath()
-        #     memory = '%dg'%obj.memory.get(),
-        #     launchSupervisedPickerGUI(micsfn, posDir, obj, mode='review', memory=memory, inTmpFolder=inTmpFolder)
-        #
-        #  # We need this case to happens before the ProtParticlePicking one
-        # elif issubclass(cls, XmippProtAssignmentTiltPair):
-        #     if obj.getOutputsSize() >= 1:
-        #         coordsSet = obj.getCoordsTiltPair()
-        #         self._visualize(coordsSet)
-        #
-        # elif issubclass(cls, ProtParticlePicking):
-        #     if obj.getOutputsSize() >= 1:
-        #         coordsSet = obj.getCoords()
-        #         self._visualize(coordsSet)
-        #
-        # elif issubclass(cls, XmippProtValidateNonTilt):
-        #     outputVols = obj.outputVolumes
-        #     labels = 'id enabled comment _filename weight'
-        #     self._views.append(ObjectView(self._project, outputVols.strId(), outputVols.getFileName(),
-        #                                   viewParams={MODE: MODE_MD, VISIBLE:labels, ORDER: labels,
-        #                                               SORT_BY: 'weight desc', RENDER: '_filename'}))
-        #
-        # elif issubclass(cls, XmippProtMultiRefAlignability):
-        #     outputVols = obj.outputVolumes
-        #     labels = 'id enabled comment _filename weightAlignabilityPrecision weightAlignabilityAccuracy'
-        #     self._views.append(ObjectView(self._project, outputVols.strId(), outputVols.getFileName(),
-        #                                   viewParams={MODE: MODE_MD, VISIBLE:labels, ORDER: labels,
-        #                                               SORT_BY: 'weightAlignabilityAccuracy desc', RENDER: '_filename'}))
-        #
-        #     fn = obj.outputParticles.getFileName()
-        #     labels = 'id enabled _index _filename _xmipp_scoreAlignabilityAccuracy _xmipp_scoreAlignabilityPrecision'
-        #     labelRender = "_filename"
-        #     self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
-        #                                     viewParams={ORDER: labels,
-        #                                               VISIBLE: labels,
-        #                                               SORT_BY: '_xmipp_scoreAlignabilityAccuracy desc', RENDER:labelRender,
-        #                                               MODE: MODE_MD}))
-        #
-        #     fn = obj._getExtraPath('vol001_pruned_particles_alignability.xmd')
-        #     md = xmipp.MetaData(fn)
-        #     from plotter import XmippPlotter
-        #     from pyworkflow.em.plotter import EmPlotter
-        #     plotter = XmippPlotter()
-        #     plotter.createSubPlot('Soft-alignment validation plot','Angular Precision', 'Angular Accuracy')
-        #     plotter.plotMdFile(md, xmipp.MDL_SCORE_BY_ALIGNABILITY_PRECISION, xmipp.MDL_SCORE_BY_ALIGNABILITY_ACCURACY,
-        #                        marker='.', markersize=.55, color='red', linestyle='')
-        #     self._views.append(plotter)
-        #
-        #
-        # elif issubclass(cls, XmippProtExtractParticlesPairs):
-        #     self._visualize(obj.outputParticlesTiltPair)
+        elif (issubclass(cls, XmippProtExtractParticles) or
+              issubclass(cls, XmippProtScreenParticles)):
+            particles = obj.outputParticles
+            self._visualize(particles)
+
+            fn = obj._getPath('images.xmd')
+            if os.path.exists(fn): # it doesnt unless cls is Xmipp
+                md = xmipp.MetaData(fn)
+                # If Zscore on output images plot Zscore particle sorting
+                if md.containsLabel(xmipp.MDL_ZSCORE):
+                    from plotter import XmippPlotter
+                    xplotter = XmippPlotter(windowTitle="Zscore particles sorting")
+                    xplotter.createSubPlot("Particle sorting", "Particle number", "Zscore")
+                    xplotter.plotMd(md, False, mdLabelY=xmipp.MDL_ZSCORE)
+                    self._views.append(xplotter)
+                # If VARscore on output images plot VARscore particle sorting
+                if md.containsLabel(xmipp.MDL_SCORE_BY_VAR):
+                    from plotter import XmippPlotter
+                    xplotter = XmippPlotter(windowTitle="Variance particles sorting")
+                    xplotter.createSubPlot("Variance Histogram", "Variance", "Number of particles")
+                    xplotter.plotMd(md, False, mdLabelY=xmipp.MDL_SCORE_BY_VAR, nbins=100)
+                    self._views.append(xplotter)
+
+        elif issubclass(cls, XmippProtMovieGain):
+            self._visualize(obj.outputMovies)
+            movieGainMonitor = MonitorMovieGain(obj,
+                                                workingDir=obj.workingDir.get(),
+                                                samplingInterval=60,
+                                                monitorTime=300,
+                                                stddevValue=0.04,
+                                                ratio1Value=1.15,
+                                                ratio2Value=4.5)
+            self._views.append(MovieGainMonitorPlotter(movieGainMonitor))
+
+        elif issubclass(cls, XmippProtRotSpectra):
+            self._visualize(obj.outputClasses,
+                            viewParams={'columns': obj.SomXdim.get(),
+                                        RENDER: ' spectraPlot._filename average._filename',
+                                        ZOOM: 30,
+                                        VISIBLE:  'enabled id _size average._filename spectraPlot._filename',
+                                        'labels': 'id _size',
+                                        SORT_BY: 'id'})
+
+        elif issubclass(cls, XmippProtKerdensom):
+            self._visualize(obj.outputClasses,
+                            viewParams={'columns': obj.SomXdim.get(),
+                                       'render': 'average._filename _representative._filename',
+                                       'labels': '_size',
+                                       'sortby': 'id'})
+
+
+
+        elif issubclass(cls, XmippProtCompareReprojections):
+                fn = obj.outputParticles.getFileName()
+                labels = 'id enabled _index _xmipp_image._filename _xmipp_imageRef._filename _xmipp_imageResidual._filename _xmipp_imageCovariance._filename _xmipp_cost _xmipp_zScoreResCov _xmipp_zScoreResMean _xmipp_zScoreResVar _xmipp_continuousA _xmipp_continuousB _xmipp_continuousX _xmipp_continuousY'
+                labelRender = "_xmipp_image._filename _xmipp_imageRef._filename _xmipp_imageResidual._filename _xmipp_imageCovariance._filename"
+                self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
+                                              viewParams={ORDER: labels,
+                                                      VISIBLE: labels,
+                                                      SORT_BY: '_xmipp_cost asc', RENDER:labelRender,
+                                                      MODE: MODE_MD}))
+
+        elif issubclass(cls, XmippProtCompareAngles):
+                fn = obj.outputParticles.getFileName()
+                labels = 'id enabled _index _filename _xmipp_shiftDiff _xmipp_angleDiff'
+                labelRender = "_filename"
+                self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
+                                              viewParams={ORDER: labels,
+                                                      VISIBLE: labels,
+                                                      SORT_BY: '_xmipp_angleDiff asc', RENDER:labelRender,
+                                                      MODE: MODE_MD}))
+
+        elif issubclass(cls, XmippParticlePickingAutomatic):
+            micSet = obj.getInputMicrographs()
+            mdFn = getattr(micSet, '_xmippMd', None)
+            inTmpFolder = False
+            if mdFn:
+                micsfn = mdFn.get()
+            else:  # happens if protocol is not an xmipp one
+                micsfn = self._getTmpPath(micSet.getName() + '_micrographs.xmd')
+                writeSetOfMicrographs(micSet, micsfn)
+                inTmpFolder = True
+
+            posDir = obj._getExtraPath()
+            memory = '%dg'%obj.memory.get(),
+            launchSupervisedPickerGUI(micsfn, posDir, obj, mode='review', memory=memory, inTmpFolder=inTmpFolder)
+
+         # We need this case to happens before the ProtParticlePicking one
+        elif issubclass(cls, XmippProtAssignmentTiltPair):
+            if obj.getOutputsSize() >= 1:
+                coordsSet = obj.getCoordsTiltPair()
+                self._visualize(coordsSet)
+
+        elif issubclass(cls, ProtParticlePicking):
+            if obj.getOutputsSize() >= 1:
+                coordsSet = obj.getCoords()
+                self._visualize(coordsSet)
+
+        elif issubclass(cls, XmippProtValidateNonTilt):
+            outputVols = obj.outputVolumes
+            labels = 'id enabled comment _filename weight'
+            self._views.append(ObjectView(self._project, outputVols.strId(), outputVols.getFileName(),
+                                          viewParams={MODE: MODE_MD, VISIBLE:labels, ORDER: labels,
+                                                      SORT_BY: 'weight desc', RENDER: '_filename'}))
+
+        elif issubclass(cls, XmippProtMultiRefAlignability):
+            outputVols = obj.outputVolumes
+            labels = 'id enabled comment _filename weightAlignabilityPrecision weightAlignabilityAccuracy'
+            self._views.append(ObjectView(self._project, outputVols.strId(), outputVols.getFileName(),
+                                          viewParams={MODE: MODE_MD, VISIBLE:labels, ORDER: labels,
+                                                      SORT_BY: 'weightAlignabilityAccuracy desc', RENDER: '_filename'}))
+
+            fn = obj.outputParticles.getFileName()
+            labels = 'id enabled _index _filename _xmipp_scoreAlignabilityAccuracy _xmipp_scoreAlignabilityPrecision'
+            labelRender = "_filename"
+            self._views.append(ObjectView(self._project, obj.outputParticles.strId(), fn,
+                                            viewParams={ORDER: labels,
+                                                      VISIBLE: labels,
+                                                      SORT_BY: '_xmipp_scoreAlignabilityAccuracy desc', RENDER:labelRender,
+                                                      MODE: MODE_MD}))
+
+            fn = obj._getExtraPath('vol001_pruned_particles_alignability.xmd')
+            md = xmipp.MetaData(fn)
+            from plotter import XmippPlotter
+            from pyworkflow.em.plotter import EmPlotter
+            plotter = XmippPlotter()
+            plotter.createSubPlot('Soft-alignment validation plot','Angular Precision', 'Angular Accuracy')
+            plotter.plotMdFile(md, xmipp.MDL_SCORE_BY_ALIGNABILITY_PRECISION, xmipp.MDL_SCORE_BY_ALIGNABILITY_ACCURACY,
+                               marker='.', markersize=.55, color='red', linestyle='')
+            self._views.append(plotter)
+
+
+        elif issubclass(cls, XmippProtExtractParticlesPairs):
+            self._visualize(obj.outputParticlesTiltPair)
 
         return self._views
 

--- a/xmipp3/viewers/viewer_cl2d.py
+++ b/xmipp3/viewers/viewer_cl2d.py
@@ -23,7 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-from pyworkflow.em.packages.xmipp3.convert import readSetOfClasses
+from xmipp3.convert import readSetOfClasses
 """
 This module implement the wrappers aroung Xmipp CL2D protocol
 visualization program.
@@ -33,7 +33,7 @@ import os
 import pyworkflow.em as em
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.protocol.params import LabelParam, BooleanParam, LEVEL_ADVANCED
-from protocol_cl2d import XmippProtCL2D
+from xmipp3.protocols.protocol_cl2d import XmippProtCL2D
 import pyworkflow.em.showj as showj
 from pyworkflow.protocol.params import EnumParam, StringParam
 

--- a/xmipp3/viewers/viewer_cltomo.py
+++ b/xmipp3/viewers/viewer_cltomo.py
@@ -30,7 +30,7 @@ visualization program.
 
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em import *
-from protocol_cltomo import XmippProtCLTomo
+from xmipp3.protocols.protocol_cltomo import XmippProtCLTomo
 from pyworkflow.gui.text import *
 from pyworkflow.protocol.params import LabelParam
 from pyworkflow.gui.dialog import showError, showWarning

--- a/xmipp3/viewers/viewer_ctf_discrepancy.py
+++ b/xmipp3/viewers/viewer_ctf_discrepancy.py
@@ -25,7 +25,7 @@
 # **************************************************************************
 
 
-from protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
+from xmipp3.protocols.protocol_ctf_discrepancy import XmippProtCTFDiscrepancy
 from pyworkflow.em import data
 from pyworkflow.em.plotter import EmPlotter
 from pyworkflow.em.viewer import ObjectView

--- a/xmipp3/viewers/viewer_extract_unit_cell.py
+++ b/xmipp3/viewers/viewer_extract_unit_cell.py
@@ -31,7 +31,7 @@ from os.path import exists
 
 import pyworkflow.em as em
 import pyworkflow.protocol.params as params
-from protocol_extract_unit_cell import XmippProtExtractUnit
+from xmipp3.protocols.protocol_extract_unit_cell import XmippProtExtractUnit
 from pyworkflow.em.constants import SYM_I222
 from pyworkflow.em.convert import ImageHandler
 from pyworkflow.em.data import (SetOfVolumes)

--- a/xmipp3/viewers/viewer_ml2d.py
+++ b/xmipp3/viewers/viewer_ml2d.py
@@ -32,7 +32,7 @@ import os
 
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.protocol.params import LabelParam
-from protocol_ml2d import XmippProtML2D
+from xmipp3.protocols.protocol_ml2d import XmippProtML2D
 import pyworkflow.em as em
 import pyworkflow.em.showj as showj
 from pyworkflow.protocol.params import EnumParam, StringParam
@@ -125,7 +125,7 @@ class XmippML2DViewer(ProtocolViewer):
 
 def createPlots(protML, selectedPlots):
     ''' Launch some plot for an ML2D protocol run '''
-    from pyworkflow.em.packages.xmipp3.plotter import XmippPlotter
+    from xmipp3.viewers.plotter import XmippPlotter
     import xmipp
     
     protML._plot_count = 0

--- a/xmipp3/viewers/viewer_mltomo.py
+++ b/xmipp3/viewers/viewer_mltomo.py
@@ -36,7 +36,7 @@ import pyworkflow.em.showj as showj
 import pyworkflow.em.metadata as md
 from pyworkflow.protocol.params import EnumParam, NumericRangeParam, LabelParam
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
-from protocol_mltomo import XmippProtMLTomo
+from xmipp3.protocols.protocol_mltomo import XmippProtMLTomo
 
 ITER_LAST = 0
 ITER_SELECTION = 1

--- a/xmipp3/viewers/viewer_movie_alignment.py
+++ b/xmipp3/viewers/viewer_movie_alignment.py
@@ -27,10 +27,10 @@
 from pyworkflow.viewer import Viewer, DESKTOP_TKINTER, WEB_DJANGO
 import pyworkflow.em.showj as showj
 
-from protocol_movie_opticalflow import (XmippProtOFAlignment,
+from xmipp3.protocols.protocol_movie_opticalflow import (XmippProtOFAlignment,
                                         OBJCMD_MOVIE_ALIGNCARTESIAN)
-from protocol_movie_correlation import XmippProtMovieCorr
-from protocol_movie_max_shift import XmippProtMovieMaxShift
+from xmipp3.protocols.protocol_movie_correlation import XmippProtMovieCorr
+from xmipp3.protocols.protocol_movie_max_shift import XmippProtMovieMaxShift
 
 class XmippMovieAlignViewer(Viewer):
     _targets = [XmippProtOFAlignment, XmippProtMovieCorr, XmippProtMovieMaxShift]

--- a/xmipp3/viewers/viewer_normalize_strain.py
+++ b/xmipp3/viewers/viewer_normalize_strain.py
@@ -26,10 +26,10 @@
 
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import DataView, ChimeraView
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.viewers import XmippViewer
 from pyworkflow.protocol.params import PointerParam, LabelParam
 
-from protocol_normalize_strain import XmippProtNormalizeStrain
+from xmipp3.protocols.protocol_normalize_strain import XmippProtNormalizeStrain
 
 class XmippNormalizeStrainViewer(ProtocolViewer):
     """ Visualize the output of protocol volume strain """

--- a/xmipp3/viewers/viewer_ransac.py
+++ b/xmipp3/viewers/viewer_ransac.py
@@ -29,8 +29,8 @@ visualization program.
 """
 from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em import *
-from protocol_ransac import XmippProtRansac
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.protocols.protocol_ransac import XmippProtRansac
+from xmipp3.viewers import XmippViewer
 
 class XmippViewerRansac(XmippViewer):
     """ Wrapper to visualize Ransac results """

--- a/xmipp3/viewers/viewer_reconstruct_highres.py
+++ b/xmipp3/viewers/viewer_reconstruct_highres.py
@@ -30,11 +30,11 @@
 from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO, ProtocolViewer
 from pyworkflow.em.viewer import ObjectView, DataView, ChimeraClientView
 import pyworkflow.em.showj as showj
-from protocol_reconstruct_highres import XmippProtReconstructHighRes
+from xmipp3.protocols.protocol_reconstruct_highres import XmippProtReconstructHighRes
 from plotter import XmippPlotter
 from glob import glob
 from os.path import exists, join
-from pyworkflow.em.packages.xmipp3.convert import getImageLocation
+from xmipp3.convert import getImageLocation
 from pyworkflow.protocol.params import EnumParam, NumericRangeParam, LabelParam, IntParam, FloatParam
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from xmipp import MDL_SAMPLINGRATE, MDL_ANGLE_ROT, MDL_ANGLE_TILT, MDL_RESOLUTION_FREQ, MDL_RESOLUTION_FRC, MetaData

--- a/xmipp3/viewers/viewer_resolution3d.py
+++ b/xmipp3/viewers/viewer_resolution3d.py
@@ -41,8 +41,8 @@ from plotter import XmippPlotter
 
 import xmipp
 
-from convert import getImageLocation
-from protocol_resolution3d import XmippProtResolution3D
+from xmipp3.convert import getImageLocation
+from xmipp3.protocols.protocol_resolution3d import XmippProtResolution3D
 
 
 FREQ_LABEL = 'frequency (1/A)'
@@ -136,7 +136,7 @@ class XmippResolution3DViewer(ProtocolViewer):
         f.close()
             
     def _loadData(self):
-        from pyworkflow.em.packages.xmipp3.nma.data import PathData
+        from xmipp3.protocols.nma.data import PathData
         data = PathData(dim=2)
         bfactorFile = self.protocol._getPath('bfactor.txt')
         if os.path.exists(bfactorFile):

--- a/xmipp3/viewers/viewer_resolution_monogenic_signal.py
+++ b/xmipp3/viewers/viewer_resolution_monogenic_signal.py
@@ -31,11 +31,11 @@ from pyworkflow.em.viewer import LocalResolutionViewer
 from pyworkflow.em.constants import (COLOR_JET, COLOR_TERRAIN,
  COLOR_GIST_EARTH, COLOR_GIST_NCAR, COLOR_GNU_PLOT, COLOR_GNU_PLOT2,
  COLOR_OTHER, COLOR_CHOICES, AX_X, AX_Y, AX_Z)
-from pyworkflow.em.packages.xmipp3.plotter import XmippPlotter
+from xmipp3.viewers.plotter import XmippPlotter
 from pyworkflow.protocol.params import (LabelParam, StringParam, EnumParam,
                                         IntParam, LEVEL_ADVANCED)
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER
-from protocol_resolution_monogenic_signal import (XmippProtMonoRes,
+from xmipp3.protocols.protocol_resolution_monogenic_signal import (XmippProtMonoRes,
                                                   OUTPUT_RESOLUTION_FILE,
                                                   OUTPUT_RESOLUTION_FILE_CHIMERA,
                                                   FN_METADATA_HISTOGRAM, CHIMERA_RESOLUTION_VOL)

--- a/xmipp3/viewers/viewer_solid_angles.py
+++ b/xmipp3/viewers/viewer_solid_angles.py
@@ -33,7 +33,7 @@ from pyworkflow.viewer import Viewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import ObjectView
 import pyworkflow.em.showj as showj 
 
-from protocol_solid_angles import XmippProtSolidAngles
+from xmipp3.protocols.protocol_solid_angles import XmippProtSolidAngles
 
 
 

--- a/xmipp3/viewers/viewer_split_volume.py
+++ b/xmipp3/viewers/viewer_split_volume.py
@@ -23,18 +23,18 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-from pyworkflow.em.packages.xmipp3.convert import readSetOfClasses
+from xmipp3.convert import readSetOfClasses
 """
 This module implement the wrappers aroung Xmipp CL2D protocol
 visualization program.
 """
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em import *
-from protocol_split_volume import XmippProtSplitvolume
+from xmipp3.protocols.protocol_split_volume import XmippProtSplitvolume
 from pyworkflow.gui.text import *
 from pyworkflow.gui.dialog import showError, showWarning
 from pyworkflow.protocol.params import LabelParam, LEVEL_ADVANCED
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.viewers import XmippViewer
 import glob
 
 class XmippViewerSplitVolume(XmippViewer):

--- a/xmipp3/viewers/viewer_swarm.py
+++ b/xmipp3/viewers/viewer_swarm.py
@@ -28,11 +28,11 @@
 # **************************************************************************
 
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer, ObjectView, DataView
+from xmipp3.viewers import XmippViewer, ObjectView, DataView
 import pyworkflow.em.showj as showj
 import xmipp
 
-from protocol_reconstruct_swarm import XmippProtReconstructSwarm
+from xmipp3.protocols.protocol_reconstruct_swarm import XmippProtReconstructSwarm
 
 class XmippReconstructSwarmViewer(XmippViewer):
     """ Visualize the output of protocol reconstruct swarm """

--- a/xmipp3/viewers/viewer_validate_nontilt.py
+++ b/xmipp3/viewers/viewer_validate_nontilt.py
@@ -29,7 +29,7 @@ from pyworkflow.em.showj import RENDER, ORDER, VISIBLE, MODE, MODE_MD
 from pyworkflow.em.viewer import DataView
 import pyworkflow.em.metadata as md
 from pyworkflow.protocol.params import LabelParam, StringParam
-from protocol_validate_nontilt import XmippProtValidateNonTilt
+from xmipp3.protocols.protocol_validate_nontilt import XmippProtValidateNonTilt
 from plotter import XmippPlotter
 
 

--- a/xmipp3/viewers/viewer_validate_overfitting.py
+++ b/xmipp3/viewers/viewer_validate_overfitting.py
@@ -27,7 +27,7 @@
 
 from pyworkflow.viewer import Viewer, DESKTOP_TKINTER, WEB_DJANGO
 import pyworkflow.em.metadata as md
-from protocol_validate_overfitting import XmippProtValidateOverfitting
+from xmipp3.protocols.protocol_validate_overfitting import XmippProtValidateOverfitting
 from pyworkflow.gui.plotter import plt
 from plotter import XmippPlotter
 import xmipp

--- a/xmipp3/viewers/viewer_volume_strain.py
+++ b/xmipp3/viewers/viewer_volume_strain.py
@@ -29,9 +29,9 @@
 
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import DataView, ChimeraView
-from pyworkflow.em.packages.xmipp3.viewer import XmippViewer
+from xmipp3.viewers import XmippViewer
 
-from protocol_volume_strain import XmippProtVolumeStrain
+from xmipp3.protocols.protocol_volume_strain import XmippProtVolumeStrain
 
 class XmippVolumeStrainViewer(XmippViewer):
     """ Visualize the output of protocol volume strain """

--- a/xmipp3/wizards.py
+++ b/xmipp3/wizards.py
@@ -176,7 +176,7 @@
 #         numberOfClasses = 64
 #
 #         if protocol.inputParticles.hasValue():
-#             from protocol_cl2d import IMAGES_PER_CLASS
+#             from xmipp3.protocols.protocol_cl2d import IMAGES_PER_CLASS
 #             numberOfClasses = int(protocol.inputParticles.get().getSize()/IMAGES_PER_CLASS)
 #
 #         return numberOfClasses


### PR DESCRIPTION
Now scipion runs and I tested some protocols and viewers.

./scipion tests --show doesn't find any test from the plugin (the same for relion and eman2)

All this is done with the old software/em/xmipp/... binaries and binning.

Next step, install xmipp from the new repositories and test discovering.